### PR TITLE
Ensures LF endings rather than CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Forces Windows to format to LF rather than CRLF