### PR TITLE
Add auto deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NUbook
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/d89a0d60-217a-4563-ad03-65ccc90b9222/deploy-status)](https://app.netlify.com/sites/nubook/deploys)
+
 NUbook is the handbook and high-level documentation for the NUbots team. You can read the latest version at https://nubook.netlify.com/.
 
 Read on if you want to add or update content.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NUbook
 
-NUbook is the handbook and high-level documentation for the NUbots team. You can read the latest version at https://nubots.github.io/NUbook/.
+NUbook is the handbook and high-level documentation for the NUbots team. You can read the latest version at https://nubook.netlify.com/.
 
 Read on if you want to add or update content.
 
@@ -97,13 +97,14 @@ NUbook uses [KaTeX](https://katex.org/) to render math. See https://katex.org/do
 
 ## Organising pages
 
-Pages are written in MDX files in the [`src/book/`](src/book/) directory, and organised as follows:
+Pages are written in MDX files and stored in section and chapter folders in the [`src/book/`](src/book/) directory, and organised as follows:
 
 - Each page's filename is numbered to create the order that will be used for menus and the previous/next page navigation links.
 - Each page has "frontmatter" at the top of the file specifying details such as title and description:
 
 ```md
 ---
+section: The NUbots Team
 chapter: Introduction
 title: Introduction to NUbots
 description: Learn about what we do, key people, and where to find the lab.
@@ -115,7 +116,8 @@ slug: /
 
 | Field         | Type    | Presence | Description                                                                 |
 | ------------- | ------- | -------- | --------------------------------------------------------------------------- |
-| `chapter`     | String  | Required | The section the page will appear under in the sidebar menu (case sensitive) |
+| `section`     | String  | Required | The section the page will appear under in the sidebar menu (case sensitive) |
+| `chapter`     | String  | Required | The chapter the page will appear under in the sidebar menu (case sensitive) |
 | `title`       | String  | Required | The page title                                                              |
 | `description` | String  | Required | A short, one-sentence description of the page content                       |
 | `slug`        | String  | Required | The page URL relative to the root of the site, starting with `/`            |
@@ -135,18 +137,6 @@ If you need to, you can:
 
 ## Deploying
 
-> **Note:** deploys can only be run from `master`, after changes have been reviewed and merged via a pull request.
+Pull requests are automatically deployed as previews using [Netlify](https://netlify.com/), which will run code quality checks and report failures before a deploy.
 
-To deploy, run:
-
-```sh
-yarn deploy
-```
-
-Deploying does the following:
-
-- Verifies that the current Git branch is `master`.
-- Lints the code for formatting and other issues. The deploy will be aborted with an error if any issues are found.
-- Cleans Gatsby's `.cache` and `public` folders and runs a fresh build.
-- Copies the built artefacts from the `public` folder into the `gh-pages` branch.
-- Commits and pushes the changes, triggering an automatic deploy to the live site on GitHub Pages.
+When a pull request is merged into master, it is automatically deployed to the main site.

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "clean": "rimraf .cache/ public/",
     "lint": "eslint \"scripts/**/*.js\" \"src/**/*.{jsx,js}\" \"*.js\"",
     "format": "prettier --write \"scripts/**/*.js\" \"src/**/*.{css,jsx,js,mdx}\" \"*.js\"",
-    "format:check": "prettier --check \"scripts/**/*.js\" \"src/**/*.{css,jsx,js,mdx}\" \"*.js\"",
-    "deploy": "node scripts/verify-deploy-branch.js && npm run lint && npm run clean && gatsby build --prefix-paths && gh-pages -d public"
+    "format:check": "prettier --check \"scripts/**/*.js\" \"src/**/*.{css,jsx,js,mdx}\" \"*.js\""
   },
   "repository": {
     "type": "git",

--- a/src/book/02-projects/03-hardware/01-overview.mdx
+++ b/src/book/02-projects/03-hardware/01-overview.mdx
@@ -8,7 +8,4 @@ slug: /projects/hardware/overview
 
 The platform used is the NUgus, based off the [igus® Humanoid Open Platform](http://www.nimbro.net/OP/). The NUgus robots are 3D printed using fused deposition modelling. Because of this, the components of the robot were split to allow for the size of the printer bed and the printer volume. The torso was also modified to have open shoulder covers for shoulder servo cable access.
 
-![Coronal image of the NUgus robot](../../../images/front-robot.png)
-![Sagittal image of the NUgus robot](../../../images/side-robot.png)
-
 The arms and head of the NUgus robot use [MX64AR servos from Dynamixel](http://www.robotis.us/dynamixel-mx-64ar/). The legs use [MX106 servos from Dynamixel](http://support.robotis.com/en/product/actuator/dynamixel/mx_series/mx-106.htm). The robots use two [FLIR Blackfly S](https://flir.app.boxcn.net/s/x0r0bdsjstdkudjd2dwlxoa5fdvj2gpg/file/418603726810) cameras positioned in their head. In the torso lies the Intel NUC7i7bnh, 8GB RAM, 256GB SSD, Robotis CM740 subcontroller, and a 3850mAh 4s LiPo battery.

--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -140,10 +140,10 @@ This paragraph has some `code` in it.
 This paragraph has some `code` in it.
 ```
 
-![Alt Text](http://placehold.it/200x50 'Image Title')
+![Alt Text](https://placehold.it/200x50 'Image Title')
 
 ```md
-![Alt Text](http://placehold.it/200x50 'Image Title')
+![Alt Text](https://placehold.it/200x50 'Image Title')
 ```
 
 ![Alt Text](../images/nubots-icon.png 'NUbots icon')


### PR DESCRIPTION
This PR adds support for Netlify deploys:

- Deploys pull requests and commits, and updating checks on GitHub
- Deploys merge commits on master to the main site
- Removes missing images that are blocking a deploy. They're added again in #13. 
- Updates README with new deploy information

Preview link for this PR: https://deploy-preview-14--nubook.netlify.com/