### PR TITLE
Improve Markdown content styles

### DIFF
--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -245,13 +245,17 @@ $$
 <Alert type='warning'>Single line warning</Alert>
 
 <Alert type='warning'>
-Be careful not to lorem ipsum dolor sit amet, consectetur adipisicing elit.
-Autem quo deserunt amet suscipit, fuga ullam cumque accusamus doloremque rem
+
+Be careful not to `lorem` ipsum dolor sit amet, consectetur adipisicing elit.
+Autem quo deserunt amet suscipit, fuga ullam cumque [accusamus doloremque](#) rem
 qui?
 
-Be careful not to lorem ipsum dolor sit amet, consectetur adipisicing elit.
-Autem quo deserunt amet suscipit, fuga ullam cumque accusamus doloremque rem
+Be careful not to **lorem ipsum dolor** sit amet, consectetur adipisicing elit.
+Autem quo deserunt amet suscipit, _fuga ullam_ cumque accusamus doloremque rem
 qui?
+
+> Don't do this.
+> Pretty improtant
 
 </Alert>
 

--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -73,26 +73,46 @@ This is a paragraph.
 * Blue
 
 - Red
+  - Nested list item
+  - Nested list item
+    - Further nested list item
+    - Further nested list item
+  - Back to nested list item
 - Green
+  - Nested list item
+    - Further nested list item
+  - Back to nested list item
 - Blue
 
 1. Buy flour and salt
-1. Mix together with water
-1. Bake
+
+   - Nested list item
+   - Nested list item
+     - Further nested list item
+     - Further nested list item
+   - Back to nested list item
+
+2. Mix together with water
+
+   1. Nested list item
+   2. Nested list item
+
+      1. Further nested list item
+      2. Further nested list item
+
+   3 Back to nested list item
+
+3. Bake
+
+4. Buy flour and salt
+5. Mix together with water
+6. Bake
 
 Paragraph:
 
 ```md
 Code
 ```
-
-<!-- -->
-
----
-
----
-
----
 
 ---
 

--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -128,25 +128,36 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptati
 
 3. Bake
 
-```js
-const oven = Oven.acquire()
-const dough = Dough.acquire()
-oven
-  .prepare()
-  .preheat()
-  .place(dough)
-  .bake()
-// Pretty long comment line to force a scrollbar. Writing a random long sentence is not as easy as it may seem. You have to really string together words and phrases that somehow work without really saying anything.
-```
+   ```js
+   const oven = Oven.acquire()
+   const dough = Dough.acquire()
+   oven
+     .prepare()
+     .preheat()
+     .place(dough)
+     .bake()
+   // Pretty long comment line to force a scrollbar. Writing a random long sentence is not as easy as it may seem. You have to really string together words and phrases that somehow work without really saying anything.
+   ```
 
 4. Buy flour and salt
 5. **Mix together with water**
 
-Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
+   Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
 
-Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
+   Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
 
 6. Bake
+7. Profit
+
+   <details>
+
+   <summary>But how tho?</summary>
+
+   Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
+
+   Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
+
+   </details>
 
 ---
 

--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -114,6 +114,13 @@ Paragraph:
 Code
 ```
 
+```
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+
+> Oh hai Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+```
+
 ---
 
 ---

--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -56,6 +56,8 @@ hidden: true
 
 ###### Header 6 `some code` here
 
+---
+
 # Paragraphs
 
 Lorem ipsum dolor sit amet, _consectetur adipisicing_ elit. Debitis ut necessitatibus alias amet blanditiis ullam asperiores totam a odio sint?
@@ -63,6 +65,8 @@ Lorem ipsum dolor sit amet, _consectetur adipisicing_ elit. Debitis ut necessita
 Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto pariatur debitis suscipit culpa `ratione expedita` obcaecati consectetur, voluptatum est nam aliquid **facilis assumenda veritatis** ad doloremque repellendus praesentium officia. Harum beatae tempora quae, id ipsam sapiente saepe ducimus quibusdam quisquam.
 
 Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptatibus nostrum nulla, [voluptates deserunt accusantium](#link) cum ipsam itaque nobis quaerat alias sapiente mollitia, laudantium possimus fugiat ipsa animi unde quae architecto ad ex debitis odio! Minus enim quisquam aliquam perferendis, rerum, voluptatum ex suscipit porro ad distinctio autem.
+
+---
 
 # Blockquotes
 
@@ -74,12 +78,13 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptati
 > hi there
 > ```
 >
-> <details>
->
-> <summary>More details</summary>
-    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus atque
-    veniam, nesciunt iste neque vero natus suscipit voluptas repudiandae odit?
-</details>
+> - Item 1
+>   1. Oh a nested item
+>   2. Other nested item
+> - Item 2
+> - Item 3
+
+---
 
 # Lists
 
@@ -87,9 +92,9 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptati
 - Green
 - Blue
 
-* Red
-* Green
-* Blue
+* Red Star
+* Green Star
+* Blue Star
 
 - Red
   - Nested list item
@@ -119,26 +124,33 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptati
       1. Further nested list item
       2. Further nested list item
 
-   3 Back to nested list item
+   3. Back to nested list item
 
 3. Bake
 
+```js
+const oven = Oven.acquire()
+const dough = Dough.acquire()
+oven
+  .prepare()
+  .preheat()
+  .place(dough)
+  .bake()
+// Pretty long comment line to force a scrollbar. Writing a random long sentence is not as easy as it may seem. You have to really string together words and phrases that somehow work without really saying anything.
+```
+
 4. Buy flour and salt
-5. Mix together with water
+5. **Mix together with water**
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
+
 6. Bake
 
-Code
-
-```
-Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
-
-> Oh hai Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
-> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
-```
-
 ---
 
----
+# Links and inline formatting
 
 This is [an example](http://example.com 'Example') link.
 
@@ -148,15 +160,13 @@ This is [an example][id] reference-style link.
 
 [id]: http://example.com 'Optional Title'
 
-_single asterisks_
-
 _single underscores_
 
 **double asterisks**
 
-**double underscores**
-
 This paragraph has some `code` in it.
+
+---
 
 # Grid
 
@@ -235,7 +245,7 @@ $$
 
 </Grid>
 
-# Images seamless
+## Images seamless
 
 <Grid columns='1fr 1fr' rows="1fr 1fr" caption="Some possible pets" seamless>
 
@@ -246,6 +256,8 @@ $$
 
 </Grid>
 
+---
+
 # Alerts
 
 ## Info
@@ -253,9 +265,27 @@ $$
 <Alert type='info'>Single line info</Alert>
 
 <Alert type='info'>
-  Did you know you can lorem ipsum dolor sit amet, consectetur adipisicing elit.
-  Autem quo deserunt amet suscipit, fuga ullam cumque accusamus doloremque rem
-  qui?
+
+Lorem ipsum dolor sit amet, **consectetuer adipiscing** elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. [Vestibulum enim](#) wisi, viverra nec, fringilla in, laoreet vitae, risus. `Markdown.generate();`
+
+```
+hi there
+```
+
+- Item 1
+  1. Oh a nested item
+  2. Other nested item
+- Item 2
+- Item 3
+
+<details>
+  <summary>More details</summary>
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus atque veniam,
+  nesciunt iste neque vero natus suscipit voluptas repudiandae odit?
+</details>
+
 </Alert>
 
 ## Warning
@@ -264,24 +294,37 @@ $$
 
 <Alert type='warning'>
 
-Be careful not to `lorem` ipsum dolor sit amet, consectetur adipisicing elit.
-Autem quo deserunt amet suscipit, fuga ullam cumque [accusamus doloremque](#) rem
-qui?
+Lorem ipsum dolor sit amet, **consectetuer adipiscing** elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 
-Be careful not to **lorem ipsum dolor** sit amet, consectetur adipisicing elit.
-Autem quo deserunt amet suscipit, _fuga ullam_ cumque accusamus doloremque rem
-qui?
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. [Vestibulum enim](#) wisi, viverra nec, fringilla in, laoreet vitae, risus. `Markdown.generate();`
 
-> Don't do this.
-> Pretty improtant
+```
+hi there
+```
+
+- Item 1
+  1. Oh a nested item
+  2. Other nested item
+- Item 2
+- Item 3
+
+<details>
+  <summary>More details</summary>
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus atque veniam,
+  nesciunt iste neque vero natus suscipit voluptas repudiandae odit?
+</details>
 
 </Alert>
 
-# Single images
+---
+
+# Images
 
 ![Architecture](https://source.unsplash.com/featured/1600x900/?modern+architecture 'Modern Architecture')
 
 ![NUbots icon](../images/nubots-icon.png 'NUbots icon')
+
+---
 
 # Code blocks
 
@@ -310,6 +353,8 @@ export default ({ children, className }) => {
 }
 ```
 
+---
+
 # Math
 
 ## Inline
@@ -322,12 +367,42 @@ $$
 e^{i\phi} = \cos(\phi) + i \sin(\phi)
 $$
 
+---
+
 # Table
 
 | First Header | Second Header | Third Header |
 | ------------ | ------------- | ------------ |
 | Content Cell | Content Cell  | Content Cell |
 | Content Cell | Content Cell  | Content Cell |
+
+---
+
+# Collapsible content
+
+<details>
+
+<summary>Show more details</summary>
+
+Lorem ipsum dolor sit amet, **consectetuer adipiscing** elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. [Vestibulum enim](#) wisi, viverra nec, fringilla in, laoreet vitae, risus. `Markdown.generate();`
+
+```
+hi there
+```
+
+- Item 1
+  1. Oh a nested item
+  2. Other nested item
+- Item 2
+- Item 3
+
+</details>
+
+---
+
+The following headings fill out the table of contents to test the scroll bar.
 
 # 2000
 

--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -10,37 +10,8 @@ slug: /kitchen-sink
 hidden: true
 ---
 
-[View raw (TEST.md)](https://raw.github.com/adamschwartz/github-markdown-kitchen-sink/master/README.md)
+# Headers
 
-This is a paragraph.
-
-```md
-This is a paragraph.
-```
-
-# Header 1
-
-## Header 2
-
-```md
-# Header 1
-
-## Header 2
-```
-
-# Header 1
-
-## Header 2 `OldWalkEngine` class
-
-### Header 3 `some code`
-
-#### Header 4 `some code`
-
-##### Header 5 `some code`
-
-###### Header 6
-
-```md
 # Header 1
 
 ## Header 2
@@ -52,17 +23,65 @@ This is a paragraph.
 ##### Header 5
 
 ###### Header 6
-```
+
+---
+
+# Headers with links
+
+## Header 2 [a link](#some-link) here
+
+## Header 2 [a link](#some-link) here
+
+### Header 3 [a link](#some-link) here
+
+#### Header 4 [a link](#some-link) here
+
+##### Header 5 [a link](#some-link) here
+
+###### Header 6 [a link](#some-link) here
+
+---
+
+# Headers with code
+
+## Header 2 `some code` here
+
+## Header 2 `some code` here
+
+### Header 3 `some code` here
+
+#### Header 4 `some code` here
+
+##### Header 5 `some code` here
+
+###### Header 6 `some code` here
+
+# Paragraphs
+
+Lorem ipsum dolor sit amet, _consectetur adipisicing_ elit. Debitis ut necessitatibus alias amet blanditiis ullam asperiores totam a odio sint?
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Architecto pariatur debitis suscipit culpa `ratione expedita` obcaecati consectetur, voluptatum est nam aliquid **facilis assumenda veritatis** ad doloremque repellendus praesentium officia. Harum beatae tempora quae, id ipsam sapiente saepe ducimus quibusdam quisquam.
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptatibus nostrum nulla, [voluptates deserunt accusantium](#link) cum ipsam itaque nobis quaerat alias sapiente mollitia, laudantium possimus fugiat ipsa animi unde quae architecto ad ex debitis odio! Minus enim quisquam aliquam perferendis, rerum, voluptatum ex suscipit porro ad distinctio autem.
+
+# Blockquotes
 
 > Lorem ipsum dolor sit amet, **consectetuer adipiscing** elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 >
 > Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. [Vestibulum enim](#) wisi, viverra nec, fringilla in, laoreet vitae, risus. `Markdown.generate();`
-
-```md
-> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 >
-> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. [Vestibulum enim](#) wisi, viverra nec, fringilla in, laoreet vitae, risus. `Markdown.generate();`
-```
+> ```
+> hi there
+> ```
+>
+> <details>
+>
+> <summary>More details</summary>
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus atque
+    veniam, nesciunt iste neque vero natus suscipit voluptas repudiandae odit?
+</details>
+
+# Lists
 
 - Red
 - Green
@@ -108,11 +127,7 @@ This is a paragraph.
 5. Mix together with water
 6. Bake
 
-Paragraph:
-
-```md
 Code
-```
 
 ```
 Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
@@ -133,16 +148,6 @@ This is [an example][id] reference-style link.
 
 [id]: http://example.com 'Optional Title'
 
-```md
-This is [an example](http://example.com 'Example') link.
-
-[This link](http://example.com) has no title attr.
-
-This is [an example][id] reference-style link.
-
-[id]: http://example.com 'Optional Title'
-```
-
 _single asterisks_
 
 _single underscores_
@@ -151,21 +156,7 @@ _single underscores_
 
 **double underscores**
 
-```md
-_single asterisks_
-
-_single underscores_
-
-**double asterisks**
-
-**double underscores**
-```
-
 This paragraph has some `code` in it.
-
-```md
-This paragraph has some `code` in it.
-```
 
 # Grid
 
@@ -289,10 +280,6 @@ qui?
 # Single images
 
 ![Architecture](https://source.unsplash.com/featured/1600x900/?modern+architecture 'Modern Architecture')
-
-```md
-![Architecture](https://source.unsplash.com/featured/1600x900/?architecture 'Architecture')
-```
 
 ![NUbots icon](../images/nubots-icon.png 'NUbots icon')
 

--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -87,6 +87,16 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptati
 > $$
 > e^{i\phi} = \cos(\phi) + i \sin(\phi)
 > $$
+>
+> <Alert>
+>
+> Here's an alert in a blockquote. Including some math content for good measure:
+>
+> $$
+> e^{i\phi} = \cos(\phi) + i \sin(\phi)
+> $$
+>
+> </Alert>
 
 ---
 
@@ -156,6 +166,17 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptati
    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
 
 6. Bake
+
+   <Alert>
+
+   Here's an alert in a list. Including some math content for good measure.
+
+   $$
+   e^{i\phi} = \cos(\phi) + i \sin(\phi)
+   $$
+
+   </Alert>
+
 7. Profit
 
    <details>
@@ -433,6 +454,16 @@ hi there
 $$
 e^{i\phi} = \cos(\phi) + i \sin(\phi)
 $$
+
+<Alert>
+
+Here's an alert in collapsible content. Including some math content for good measure.
+
+$$
+e^{i\phi} = \cos(\phi) + i \sin(\phi)
+$$
+
+</Alert>
 
 </details>
 

--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -54,14 +54,14 @@ This is a paragraph.
 ###### Header 6
 ```
 
-> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+> Lorem ipsum dolor sit amet, **consectetuer adipiscing** elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 >
-> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus. `Markdown.generate();`
+> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. [Vestibulum enim](#) wisi, viverra nec, fringilla in, laoreet vitae, risus. `Markdown.generate();`
 
 ```md
 > Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 >
-> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus. `Markdown.generate();`
+> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. [Vestibulum enim](#) wisi, viverra nec, fringilla in, laoreet vitae, risus. `Markdown.generate();`
 ```
 
 - Red

--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -70,7 +70,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptati
 
 # Blockquotes
 
-> Lorem ipsum dolor sit amet, **consectetuer adipiscing** elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+> Lorem ipsum dolor sit amet, **consectetuer adipiscing** elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus. $\pi = 3.14$
 >
 > Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. [Vestibulum enim](#) wisi, viverra nec, fringilla in, laoreet vitae, risus. `Markdown.generate();`
 >
@@ -83,6 +83,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptati
 >   2. Other nested item
 > - Item 2
 > - Item 3
+>
+> $$
+> e^{i\phi} = \cos(\phi) + i \sin(\phi)
+> $$
 
 ---
 
@@ -140,6 +144,11 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptati
    ```
 
 4. Buy flour and salt
+
+   $$
+   e^{i\phi} = \cos(\phi) + i \sin(\phi)
+   $$
+
 5. **Mix together with water**
 
    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
@@ -156,6 +165,10 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem quam a voluptati
    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
 
    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos totam mollitia neque architecto, esse porro expedita et nostrum dolorem nisi!
+
+   $$
+   e^{i\phi} = \cos(\phi) + i \sin(\phi)
+   $$
 
    </details>
 
@@ -297,6 +310,10 @@ hi there
   nesciunt iste neque vero natus suscipit voluptas repudiandae odit?
 </details>
 
+$$
+e^{i\phi} = \cos(\phi) + i \sin(\phi)
+$$
+
 </Alert>
 
 ## Warning
@@ -324,6 +341,10 @@ hi there
   Lorem ipsum dolor sit amet, consectetur adipisicing elit. Accusamus atque veniam,
   nesciunt iste neque vero natus suscipit voluptas repudiandae odit?
 </details>
+
+$$
+e^{i\phi} = \cos(\phi) + i \sin(\phi)
+$$
 
 </Alert>
 
@@ -408,6 +429,10 @@ hi there
   2. Other nested item
 - Item 2
 - Item 3
+
+$$
+e^{i\phi} = \cos(\phi) + i \sin(\phi)
+$$
 
 </details>
 

--- a/src/components/markdown/alert/alert.jsx
+++ b/src/components/markdown/alert/alert.jsx
@@ -8,6 +8,7 @@ import WarningIcon from './warning-icon.svg'
 const Alert = ({ children, type, hideIcon }) => {
   return (
     <div
+      data-alert
       className={`${style.alert} ${
         type == 'info' ? style.alertInfo : style.alertWarning
       }`}
@@ -17,7 +18,7 @@ const Alert = ({ children, type, hideIcon }) => {
           {type == 'info' ? <InfoIcon /> : <WarningIcon />}
         </div>
       )}
-      <div data-alert className={style.alertContent}>
+      <div data-alert-content className={style.alertContent}>
         {children}
       </div>
     </div>

--- a/src/components/markdown/alert/alert.jsx
+++ b/src/components/markdown/alert/alert.jsx
@@ -17,7 +17,9 @@ const Alert = ({ children, type, hideIcon }) => {
           {type == 'info' ? <InfoIcon /> : <WarningIcon />}
         </div>
       )}
-      <div className={style.alertContent}>{children}</div>
+      <div data-alert className={style.alertContent}>
+        {children}
+      </div>
     </div>
   )
 }

--- a/src/components/markdown/alert/alert.module.css
+++ b/src/components/markdown/alert/alert.module.css
@@ -1,5 +1,5 @@
 .alert {
-  @apply w-full max-w-full p-4 flex items-center;
+  @apply max-w-full p-4 flex items-center;
 }
 
 .alertContent {
@@ -8,6 +8,23 @@
 
 .alertContent p {
   @apply text-base mt-3;
+}
+
+.alertContent p:first-child {
+  margin-top: 0;
+}
+
+.alertContent code {
+  @apply inline-block;
+  @apply rounded-sm;
+  @apply text-sm;
+  @apply px-1;
+  @apply leading-none;
+  @apply whitespace-no-wrap;
+  @apply text-red-600;
+  @apply font-mono;
+  @apply align-baseline;
+  @apply font-normal;
 }
 
 .alertIcon {

--- a/src/components/markdown/alert/alert.module.css
+++ b/src/components/markdown/alert/alert.module.css
@@ -3,7 +3,7 @@
 }
 
 .alertContent {
-  @apply -mt-1;
+  @apply -mt-1 w-full;
 }
 
 .alertContent p {

--- a/src/components/markdown/code.jsx
+++ b/src/components/markdown/code.jsx
@@ -36,4 +36,8 @@ Code.propTypes = {
   className: PropTypes.string,
 }
 
+Code.defaultProps = {
+  className: 'language-txt',
+}
+
 export default Code

--- a/src/components/markdown/heading/heading.jsx
+++ b/src/components/markdown/heading/heading.jsx
@@ -13,7 +13,7 @@ export function createHeading(HeadingType) {
           id={anchor.props.href.replace('#', '')}
           className={style.anchor}
         ></div>
-        <a href={anchor.props.href}>
+        <a data-anchor href={anchor.props.href}>
           <LinkIcon />
         </a>
         {title}

--- a/src/components/markdown/markdown.module.css
+++ b/src/components/markdown/markdown.module.css
@@ -1,5 +1,4 @@
-.markdown,
-.markdown details {
+.markdown {
   /* ============================
    * Base text color and line height
    * ============================ */
@@ -9,39 +8,32 @@
   /* ============================
    * Vertical rythm
    * ============================ */
-  > *:first-child {
-    @apply mt-0;
+  &,
+  blockquote,
+  details {
+    > *:first-child {
+      @apply mt-0;
+    }
+
+    > * + * {
+      @apply mt-6;
+    }
   }
 
-  > * + * {
-    @apply mt-6;
-  }
-
-  > ul > * + *,
-  > ol > * + * {
+  ul > * + *,
+  ol > * + * {
     @apply mt-3;
   }
 
   /* ============================
    * Separator
    * ============================ */
-  > hr {
+  hr {
     @apply border-t-0 border-r-0 border-l-0 border-b-2 border-gray-200;
     @apply my-16;
   }
 
-  /* ============================
-   * Links
-   * ============================ */
-  > a {
-    @apply block;
-  }
-
-  > a,
-  > p a,
-  > ul li a,
-  > ol li a,
-  a& {
+  a {
     @apply text-nubots-700;
     @apply underline;
 
@@ -59,22 +51,17 @@
   /* ============================
    * Bold text
    * ============================ */
-  > p strong,
-  > ul strong {
+  strong {
     @apply font-semibold;
   }
 
   /* ============================
    * Inline code
    * ============================ */
-  > p code,
-  > ul li *:not(pre) code,
-  > ul li > code,
-  > ol li *:not(pre) code,
-  > ol li > code,
-  p& code& {
+  code,
+  *:not(pre) code {
+    background-color: rgba(0, 0, 0, 0.04);
     @apply inline-block;
-    @apply bg-gray-100;
     @apply rounded-sm;
     @apply text-sm;
     @apply px-1;
@@ -86,17 +73,13 @@
     @apply font-normal;
   }
 
-  > p strong code,
-  > ul li strong code,
-  > ol li strong code {
+  strong code {
     @apply font-semibold;
   }
 
   /* ============================
    * Code blocks
    * ============================ */
-  > pre,
-  pre&,
   pre {
     @apply font-mono;
     @apply rounded;
@@ -128,8 +111,7 @@
   /* ============================
    * Blockquotes
    * ============================ */
-  > blockquote,
-  blockquote& {
+  blockquote {
     @apply bg-gray-100;
     @apply p-4;
     @apply border-l border-l-4 border-gray-200;
@@ -141,8 +123,7 @@
   /* ============================
    * Headings
    * ============================ */
-  > h1,
-  h1& {
+  h1 {
     @apply mb-1;
     @apply leading-none;
     @apply text-primary;
@@ -150,8 +131,7 @@
     @apply text-3xl;
   }
 
-  > h2,
-  h2& {
+  h2 {
     @apply mt-10;
     @apply mb-4;
     @apply text-primary;
@@ -160,12 +140,11 @@
     @apply text-2xl;
   }
 
-  > h2 + h3 {
+  h2 + h3 {
     @apply mt-6;
   }
 
-  > h3,
-  h3& {
+  h3 {
     @apply mt-12 -mb-3;
     @apply text-primary;
     @apply leading-tight;
@@ -173,8 +152,7 @@
     @apply text-xl;
   }
 
-  > h4,
-  h4& {
+  h4 {
     @apply mb-0;
     @apply text-primary;
     @apply leading-snug;
@@ -182,64 +160,66 @@
     @apply text-lg;
   }
 
-  > h5,
-  h5& {
+  h5 {
     @apply text-primary;
     @apply leading-snug;
     @apply font-semibold;
     @apply text-base;
   }
 
-  > h1 + p {
+  h1 + p {
     @apply mt-8;
   }
 
-  > h1 > code,
-  > h2 > code,
-  > h3 > code,
-  > h4 > code,
-  > h5 > code {
+  h1 > code,
+  h2 > code,
+  h3 > code,
+  h4 > code,
+  h5 > code {
+    font-size: inherit;
     @apply text-red-600;
     @apply font-mono;
   }
 
-  > h3 > code {
+  h3 > code {
     @apply text-lg px-1 bg-gray-100 rounded;
   }
 
-  > h4 > code {
+  h4 > code {
     @apply text-base px-1 bg-gray-100 rounded;
   }
 
-  > h5 > code {
+  h5 > code {
     @apply text-base px-1 bg-gray-100;
   }
 
-  > p,
-  p&,
-  > blockquote > p:not(:first-child) {
+  p {
     @apply text-base;
     @apply mt-6;
+
+    &:first-child {
+      margin-top: 0;
+    }
   }
 
-  > h1,
-  > h2,
-  > h3,
-  > h4,
-  > h5,
-  > h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     @apply relative;
 
-    a {
+    a[data-anchor] {
       @apply absolute flex items-center opacity-0 pl-2 w-8;
       left: -32px;
       top: -4px;
       bottom: -4px;
     }
 
-    &:hover a,
-    a:hover,
-    a:focus {
+    &:hover a[data-anchor],
+    a[data-anchor]:hover,
+    a[data-anchor]:focus {
       @apply opacity-100;
     }
   }
@@ -247,10 +227,10 @@
   /* ============================
    * Lists
    * ============================ */
-  > ul {
+  ul {
     @apply pl-0 list-none;
 
-    li {
+    > li {
       @apply relative pl-10;
 
       &::before {
@@ -262,7 +242,7 @@
     }
   }
 
-  > ol {
+  ol {
     @apply list-none;
     counter-reset: item;
 
@@ -280,33 +260,26 @@
     }
   }
 
-  > :not(pre):not(h1):not(h2):not(h3):not(h4) > code,
-  > ul code,
-  > ol code {
-    @apply bg-gray-100;
+  :not(pre):not(h1):not(h2):not(h3):not(h4) > code,
+  ul code,
+  ol code {
     @apply text-sm;
     @apply leading-normal;
   }
 
-  > pre,
-  pre&,
-  > ul li pre,
-  > ol li pre {
+  pre {
     @apply flex p-0;
     @apply text-sm leading-normal;
   }
 
-  > pre code,
-  pre code&,
-  > ul li pre code,
-  > ol li pre code {
+  pre code {
     @apply p-4;
   }
 
   /* ============================
    * Tables
    * ============================ */
-  > table {
+  table {
     @apply w-full text-left;
     border-collapse: collapse !important;
 
@@ -337,22 +310,25 @@
   /* ============================
    * Collapsible sections
    * ============================ */
-  details {
+  :not(blockquote) details {
     border: 1px solid #eee;
   }
 
-  details[open] {
+  :not(blockquote) details[open] {
     padding: 16px;
   }
 
-  summary {
-    background-color: #eee;
-    padding: 8px 16px;
+  details summary {
     user-select: none;
     cursor: pointer;
   }
 
-  details[open] > summary {
+  :not(blockquote) details summary {
+    background-color: #eee;
+    padding: 8px 16px;
+  }
+
+  :not(blockquote) details[open] > summary {
     margin-top: -16px;
     margin-left: -16px;
     margin-right: -16px;

--- a/src/components/markdown/markdown.module.css
+++ b/src/components/markdown/markdown.module.css
@@ -20,6 +20,16 @@
     }
   }
 
+  [data-alert] {
+    > *:first-child {
+      @apply mt-0;
+    }
+
+    > * + * {
+      @apply mt-4;
+    }
+  }
+
   ul > * + *,
   ol > * + * {
     @apply mt-3;
@@ -58,8 +68,7 @@
   /* ============================
    * Inline code
    * ============================ */
-  code,
-  *:not(pre) code {
+  :not(pre) > code {
     background-color: rgba(0, 0, 0, 0.04);
     @apply inline-block;
     @apply rounded-sm;
@@ -115,7 +124,6 @@
     @apply bg-gray-100;
     @apply p-4;
     @apply border-l border-l-4 border-gray-200;
-    @apply italic;
     @apply text-primary;
     @apply text-base;
   }
@@ -253,10 +261,31 @@
     > li::before {
       @apply absolute top-0 left-0 mt-px ml-1;
       @apply flex items-center justify-center;
-      @apply h-6 w-6 bg-gray-300 rounded-full;
+      @apply h-6 w-6 rounded-full;
       @apply text-primary text-xs font-bold;
+      background-color: rgba(0, 0, 0, 0.07);
       content: counter(item);
       counter-increment: item;
+    }
+  }
+
+  ol,
+  ul {
+    ul,
+    ol {
+      @apply mt-2;
+    }
+
+    p,
+    pre,
+    blockquote,
+    details,
+    figure {
+      @apply mt-3;
+
+      &:first-child {
+        margin-top: 0;
+      }
     }
   }
 
@@ -310,25 +339,25 @@
   /* ============================
    * Collapsible sections
    * ============================ */
-  :not(blockquote) details {
-    border: 1px solid #eee;
-  }
-
-  :not(blockquote) details[open] {
-    padding: 16px;
-  }
-
   details summary {
     user-select: none;
     cursor: pointer;
   }
 
-  :not(blockquote) details summary {
+  > details {
+    border: 1px solid #eee;
+  }
+
+  > details[open] {
+    padding: 16px;
+  }
+
+  > details summary {
     background-color: #eee;
     padding: 8px 16px;
   }
 
-  :not(blockquote) details[open] > summary {
+  > details[open] > summary {
     margin-top: -16px;
     margin-left: -16px;
     margin-right: -16px;

--- a/src/components/markdown/markdown.module.css
+++ b/src/components/markdown/markdown.module.css
@@ -1,4 +1,5 @@
-.markdown {
+.markdown,
+.markdown details {
   /* ============================
    * Base text color and line height
    * ============================ */
@@ -331,5 +332,29 @@
    * ============================ */
   :global(.katex-display) {
     margin-bottom: 0;
+  }
+
+  /* ============================
+   * Collapsible sections
+   * ============================ */
+  details {
+    border: 1px solid #eee;
+  }
+
+  details[open] {
+    padding: 16px;
+  }
+
+  summary {
+    background-color: #eee;
+    padding: 8px 16px;
+    user-select: none;
+    cursor: pointer;
+  }
+
+  details[open] > summary {
+    margin-top: -16px;
+    margin-left: -16px;
+    margin-right: -16px;
   }
 }

--- a/src/components/markdown/markdown.module.css
+++ b/src/components/markdown/markdown.module.css
@@ -20,7 +20,7 @@
     }
   }
 
-  [data-alert] {
+  [data-alert-content] {
     > *:first-child {
       @apply mt-0;
     }
@@ -280,7 +280,8 @@
     pre,
     blockquote,
     details,
-    figure {
+    figure,
+    [data-alert] {
       @apply mt-3;
 
       &:first-child {


### PR DESCRIPTION
This refactors the CSS applied to markdown content and fixes a number of issues with things like:

- [Code](https://deploy-preview-26--nubook.netlify.com/kitchen-sink#headers-with-code) and [links](https://deploy-preview-26--nubook.netlify.com/kitchen-sink#headers-with-links) nested in headings
- Paragraphs, links, code, math, etc nested in [alerts](https://deploy-preview-26--nubook.netlify.com/kitchen-sink#alerts)
- Paragraphs, links, code, math, etc nested in [blockquotes](https://deploy-preview-26--nubook.netlify.com/kitchen-sink#blockquotes)
- Paragraphs, links, code, math, etc nested in [`<details>`](https://deploy-preview-26--nubook.netlify.com/kitchen-sink#collapsible-content)
- Arbitrarily nested [ordered and unordered lists](https://deploy-preview-26--nubook.netlify.com/kitchen-sink#lists)

[Preview updated kitchen sink](https://deploy-preview-26--nubook.netlify.com/kitchen-sink)