### PR TITLE
Fix content scroll issue when switching from long pages

### DIFF
--- a/src/components/sidebar/sidebar.jsx
+++ b/src/components/sidebar/sidebar.jsx
@@ -19,6 +19,9 @@ const Sidebar = ({ menu, currentSection }) => {
 
     if (activeLink) {
       activeLink.scrollIntoView({ block: 'center', inline: 'nearest' })
+
+      // Sometimes `scrollIntoView` scrolls the main content, so we reset it here
+      document.documentElement.scrollTop = 0
     }
   }, [])
 


### PR DESCRIPTION
This PR fixes the issue where the scroll to the active link in the sidebar also scrolls the main content area.

To see current behaviour, go to https://nubook.netlify.com/team/publications and scroll about halfway down the page, then click **Team History** in the sidebar. You'll notice that (in Chrome) the main content has been scrolled, and doesn't show the page title.

To see the fix, do the same here: https://deploy-preview-39--nubook.netlify.com/team/publications