### PR TITLE
Add component to show images in tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,25 @@ The [columns](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-col
 
 See the [original pull request](https://github.com/NUbots/NUbook/pull/20) for more examples.
 
+### Showing images in tabs
+
+You can show multiple images in the same place by putting them in tabs. The caption of each image is used for the tab button label.
+
+The following example shows four images in tabs:
+
+```mdx
+<TabbedImages>
+
+![Bird](https://source.unsplash.com/featured/1600x900/?bird,1 'Bird')
+![Cat](https://source.unsplash.com/featured/1600x900/?cat,1 'Cat')
+![Dog](https://source.unsplash.com/featured/1600x900/?dog,1 'Dog')
+![Turtle](https://source.unsplash.com/featured/1600x900/?turtle,1 'Turtle')
+
+</TabbedImages>
+```
+
+See what the tabs look like in the [kitchen sink](https://nubook.netlify.com/kitchen-sink#tabbed-images).
+
 ### Showing alerts and warnings
 
 You can show an informational alert using:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See the [original pull request](https://github.com/NUbots/NUbook/pull/20) for mo
 
 ### Showing images in tabs
 
-You can show multiple images in the same place by putting them in tabs. The caption of each image is used for the tab button label.
+You can show multiple images in the same place by putting them in tabs. The caption of each image is used for its tab button label.
 
 The following example shows four images in tabs:
 

--- a/src/book/kitchen-sink.mdx
+++ b/src/book/kitchen-sink.mdx
@@ -303,6 +303,19 @@ $$
 
 ---
 
+# Tabbed images
+
+<TabbedImages>
+
+![Bird](https://source.unsplash.com/featured/1600x900/?bird,11 'Bird')
+![Cat](https://source.unsplash.com/featured/1600x900/?cat,11 'Cat')
+![Dog](https://source.unsplash.com/featured/1600x900/?dog,11 'Dog')
+![Turtle](https://source.unsplash.com/featured/1600x900/?turtle,11 'Turtle')
+
+</TabbedImages>
+
+---
+
 # Alerts
 
 ## Info

--- a/src/components/markdown/markdown.jsx
+++ b/src/components/markdown/markdown.jsx
@@ -5,6 +5,7 @@ import { MDXProvider } from '@mdx-js/react'
 import Code from './code'
 import Image from './image'
 import Link from './link'
+import TabbedImages from './tabbed-images'
 
 import Alert from './alert/alert'
 import Grid from './grid/grid'
@@ -46,6 +47,7 @@ const MDXComponents = {
   h6: createHeading('h6'),
   Alert,
   Grid,
+  TabbedImages,
 }
 
 const Markdown = ({ children }) => (

--- a/src/components/markdown/tabbed-images.jsx
+++ b/src/components/markdown/tabbed-images.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+
+const TabbedImages = ({ children }) => {
+  const [currentTab, setCurrentTab] = useState(0)
+
+  return (
+    <div>
+      <div className='bg-gray-300 flex overflow-x-auto'>
+        {children.map((child, index) => {
+          return (
+            <button
+              key={index}
+              className={`flex-shrink-0 px-3 py-1 border-r-2 border-white hover:bg-gray-400 focus:bg-gray-400 ${
+                index === currentTab
+                  ? 'font-bold bg-nubots-200 hover:bg-nubots-200 focus:bg-nubots-200'
+                  : ''
+              }`}
+              onClick={() => {
+                setCurrentTab(index)
+              }}
+            >
+              {child.props.title}
+            </button>
+          )
+        })}
+      </div>
+      <div>
+        {children.map((child, index) => {
+          return (
+            <div
+              key={index}
+              style={{ display: currentTab === index ? 'block' : 'none' }}
+            >
+              {child}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+TabbedImages.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+export default TabbedImages


### PR DESCRIPTION
This PR adds a `TabbedImages` component that can be used to show images side-by-side in tabs.

Extracted from #25 where it is used to show two alternate diagrams.

Looks like this:

<img src="https://user-images.githubusercontent.com/5924865/73624090-8bee2b80-4693-11ea-9008-98b15a95375a.png" width="400px" alt="Screenshot of images in tabs using the TabbedImages component" />

[Preview](https://deploy-preview-42--nubook.netlify.com/kitchen-sink#tabbed-images)