### PR TITLE
Fix Prettier format error

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,15 @@
     "quoteProps": "consistent",
     "trailingComma": "es5",
     "jsxBracketSameLine": false,
-    "endOfLine": "lf"
+    "endOfLine": "lf",
+    "overrides": [
+      {
+        "files": "*.mdx",
+        "options": {
+          "parser": "markdown"
+        }
+      }
+    ]
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This fixes the following errors:

![image](https://user-images.githubusercontent.com/5924865/80278504-409b6480-873a-11ea-8beb-290b5cbb59f4.png)

Currently Prettier's `mdx` parser [is broken](https://github.com/prettier/prettier/issues/7041), and fails when trying to parse JSX code blocks.

This is why code like this result in an error:

````mdx
<Alert>

```js
alert('oh hai')
```

</Alert>
````

Strangely, there's no error when using the `markdown` parser. So this PR adds a parser override to force Prettier to use the `markdown` parser for `.mdx` files.

