### PR TITLE
Fix anchor links

### DIFF
--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 
 import ArticleHeader from './article-header'
@@ -25,6 +25,7 @@ const Layout = ({ children, data, pageContext }) => {
   const currentChapter = currentSection.chapters.find(
     chapter => chapter.title === chapterTitle
   )
+  const sidebarWrapperRef = useRef(null)
   return (
     <>
       <SEO
@@ -48,9 +49,14 @@ const Layout = ({ children, data, pageContext }) => {
           <div className='hidden w-1/4 lg:block xl:w-1/5'>
             <div
               className='pl-6 pr-8 pt-10 pb-6 sticky top-0 left-0 max-h-screen overflow-y-auto border-t border-t-transparent'
+              ref={sidebarWrapperRef}
               style={{ borderTopWidth: '4rem' }}
             >
-              <Sidebar menu={menu} currentSection={currentSection} />
+              <Sidebar
+                menu={menu}
+                currentSection={currentSection}
+                wrapperRef={sidebarWrapperRef}
+              />
             </div>
           </div>
           <div className='w-full lg:flex lg:w-3/4 xl:w-4/5'>

--- a/src/components/sidebar/sidebar.jsx
+++ b/src/components/sidebar/sidebar.jsx
@@ -4,29 +4,35 @@ import { Link } from 'gatsby'
 
 import style from './sidebar.module.css'
 
+function elementInView(element, container) {
+  const top = element.offsetTop
+  const parentTop = container.scrollTop
+  const bottom = top + element.offsetHeight
+  const parentBottom = container.offsetHeight
+
+  return top >= parentTop && bottom <= parentBottom
+}
+
 const getLinkProps = ({ isCurrent }) => {
   return {
     className: `${style.link} ${isCurrent ? `${style.linkActive}` : ''}`,
   }
 }
 
-const Sidebar = ({ menu, currentSection }) => {
-  const sidebarEl = useRef(null)
+const Sidebar = ({ menu, currentSection, wrapperRef }) => {
+  const sidebarRef = useRef(null)
 
   // Scroll to reveal the active link on mount
   useEffect(() => {
-    const activeLink = sidebarEl.current.querySelector(`.${style.linkActive}`)
+    const activeLink = sidebarRef.current.querySelector(`.${style.linkActive}`)
 
-    if (activeLink) {
+    if (activeLink && !elementInView(activeLink, wrapperRef.current)) {
       activeLink.scrollIntoView({ block: 'center', inline: 'nearest' })
-
-      // Sometimes `scrollIntoView` scrolls the main content, so we reset it here
-      document.documentElement.scrollTop = 0
     }
   }, [])
 
   return (
-    <nav ref={sidebarEl}>
+    <nav ref={sidebarRef}>
       <div className='mb-8'>
         {menu.map(section => {
           const className = `${style.sectionLink} ${
@@ -81,6 +87,10 @@ Sidebar.propTypes = {
       })
     ).isRequired,
   }),
+  wrapperRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 }
 
 export default Sidebar

--- a/src/components/sidebar/sidebar.jsx
+++ b/src/components/sidebar/sidebar.jsx
@@ -89,7 +89,11 @@ Sidebar.propTypes = {
   }),
   wrapperRef: PropTypes.oneOfType([
     PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+    PropTypes.shape({
+      current: PropTypes.instanceOf(
+        typeof Element === 'undefined' ? Function : Element
+      ),
+    }),
   ]),
 }
 


### PR DESCRIPTION
This PR fixes anchor links (links that scroll to a specific section on the page).

It was broken due to the way we focused the active link in the sidebar.

Compare [this link](https://nubook.nubots.net/system/foundations/mathematics#velocity) (master, broken) with [the same link here](https://deploy-preview-76--nubook.netlify.app/system/foundations/mathematics#velocity) (this PR, fixed). Both links should open the Mathematics page and scroll to the Velocity section, but only the second works.