### PR TITLE
bscript tests tool documentation

### DIFF
--- a/src/book/02-system/01-foundations/02-build-system.mdx
+++ b/src/book/02-system/01-foundations/02-build-system.mdx
@@ -122,6 +122,7 @@ NUClear Roles introduces the `b` command that wraps up all of the functionality 
 | run       | Run a role locally                                             |
 | shell     | Exposes a shell in the Docker image                            |
 | target    | Select a target to work on                                     |
+| tests     | Run built unit tests                                    |
 
 ##### Build
 
@@ -343,6 +344,43 @@ The `generic` target is useful if you would like to build and run code on your l
 The `nuc7i7bnh` target should be used for building and running code on the robots.
 
 The `target` command will download (or, if needed, build) the Docker image for the specified target and then mark that target as active.
+
+##### Tests
+
+The `tests` command allows you to run built unit tests. It will automatically run tests in parallel, and dump a timestamped log file to the project directory.
+Currently, we use `CTest` which is included as part of `CMake`.
+
+In order to run unit tests, they must first be built, this can be done with
+
+```bash
+./b configure -- -DBUILD_TESTS=ON
+./b build
+```
+The `tests` command provides the following subcommands
+
+| Subcommand     | Description                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| list           | List all built tests                                                                       |
+| run            | Run all or individual tests                                                                |
+
+If you would like to run a individual test (or group of tests), you can pass the `run` subcommand a string and it will only run tests that match the given string.
+Alternatively, `run` will run all built tests if no string is passed.
+
+For example, if you would like to run all tests with the string 'vision' in their name, you would do
+
+```bash
+./b tests run vision
+```
+
+The `run` subcommand also accepts the following flags
+
+| Flag                               | Description                                                                                |
+| ---------------------------------- | ------------------------------------------------------------------------------------------ |
+| -V or --verbose                    |  Enable verbose output from tests                                                          |
+| -VV or --extra-verbose             |  Enable more verbose output from tests                                                     |
+| -Q or --quiet                      |  Make ctest not print to stdout                                                            |
+| -j NUM_JOBS or --parallel NUM_JOBS |  Run the tests in parallel using the given number of jobs.                                 |
+| --debug                            |  Displaying more verbose internals of CTest                                                |
 
 ## Docker Images
 

--- a/src/book/02-system/01-foundations/02-build-system.mdx
+++ b/src/book/02-system/01-foundations/02-build-system.mdx
@@ -122,7 +122,7 @@ NUClear Roles introduces the `b` command that wraps up all of the functionality 
 | run       | Run a role locally                                             |
 | shell     | Exposes a shell in the Docker image                            |
 | target    | Select a target to work on                                     |
-| tests     | Run built unit tests                                    |
+| tests     | Run built unit tests                                           |
 
 ##### Build
 
@@ -356,12 +356,13 @@ In order to run unit tests, they must first be built, this can be done with
 ./b configure -- -DBUILD_TESTS=ON
 ./b build
 ```
+
 The `tests` command provides the following subcommands
 
-| Subcommand     | Description                                                                                |
-| -------------- | ------------------------------------------------------------------------------------------ |
-| list           | List all built tests                                                                       |
-| run            | Run all or individual tests                                                                |
+| Subcommand | Description                 |
+| ---------- | --------------------------- |
+| list       | List all built tests        |
+| run        | Run all or individual tests |
 
 If you would like to run a individual test (or group of tests), you can pass the `run` subcommand a string and it will only run tests that match the given string.
 Alternatively, `run` will run all built tests if no string is passed.
@@ -374,13 +375,13 @@ For example, if you would like to run all tests with the string 'vision' in thei
 
 The `run` subcommand also accepts the following flags
 
-| Flag                               | Description                                                                                |
-| ---------------------------------- | ------------------------------------------------------------------------------------------ |
-| -V or --verbose                    |  Enable verbose output from tests                                                          |
-| -VV or --extra-verbose             |  Enable more verbose output from tests                                                     |
-| -Q or --quiet                      |  Make ctest not print to stdout                                                            |
-| -j NUM_JOBS or --parallel NUM_JOBS |  Run the tests in parallel using the given number of jobs.                                 |
-| --debug                            |  Displaying more verbose internals of CTest                                                |
+| Flag                               | Description                                               |
+| ---------------------------------- | --------------------------------------------------------- |
+| -V or --verbose                    | Enable verbose output from tests                          |
+| -VV or --extra-verbose             | Enable more verbose output from tests                     |
+| -Q or --quiet                      | Make ctest not print to stdout                            |
+| -j NUM_JOBS or --parallel NUM_JOBS | Run the tests in parallel using the given number of jobs. |
+| --debug                            | Displaying more verbose internals of CTest                |
 
 ## Docker Images
 

--- a/src/book/02-system/01-foundations/02-build-system.mdx
+++ b/src/book/02-system/01-foundations/02-build-system.mdx
@@ -347,40 +347,39 @@ The `target` command will download (or, if needed, build) the Docker image for t
 
 ##### Tests
 
-The `tests` command allows you to run built unit tests. It will automatically run tests in parallel, and dump a timestamped log file to the project directory.
-Currently, we use `CTest` which is included as part of `CMake`.
+The `tests` command allows you to run built unit tests. It will automatically run tests in parallel, and dump a timestamped log file to the project directory. Currently, we use [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html) which is included as part of CMake.
 
-In order to run unit tests, they must first be built, this can be done with
+In order to run unit tests, they must first be built. This can be done with:
 
 ```bash
 ./b configure -- -DBUILD_TESTS=ON
 ./b build
 ```
 
-The `tests` command provides the following subcommands
+The `tests` command provides the following subcommands:
 
 | Subcommand | Description                 |
 | ---------- | --------------------------- |
 | list       | List all built tests        |
 | run        | Run all or individual tests |
 
-If you would like to run a individual test (or group of tests), you can pass the `run` subcommand a string and it will only run tests that match the given string.
+If you would like to run an individual test (or group of tests), you can pass the `run` subcommand a string and it will only run tests that match the given string.
 Alternatively, `run` will run all built tests if no string is passed.
 
-For example, if you would like to run all tests with the string 'vision' in their name, you would do
+For example, if you would like to run all tests with the string 'vision' in their name, you would do:
 
 ```bash
 ./b tests run vision
 ```
 
-The `run` subcommand also accepts the following flags
+The `run` subcommand also accepts the following flags:
 
 | Flag                               | Description                                               |
 | ---------------------------------- | --------------------------------------------------------- |
-| -V or --verbose                    | Enable verbose output from tests                          |
-| -VV or --extra-verbose             | Enable more verbose output from tests                     |
-| -Q or --quiet                      | Make ctest not print to stdout                            |
-| -j NUM_JOBS or --parallel NUM_JOBS | Run the tests in parallel using the given number of jobs. |
+| `-V` or `--verbose`                    | Enable verbose output from tests                          |
+| `-VV` or `--extra-verbose`             | Enable more verbose output from tests                     |
+| `-Q` or `--quiet`                      | Make CTest not print to stdout                            |
+| `-j NUM_JOBS` or `--parallel NUM_JOBS` | Run the tests in parallel using the given number of jobs |
 | --debug                            | Displaying more verbose internals of CTest                |
 
 ## Docker Images

--- a/src/book/02-system/01-foundations/02-build-system.mdx
+++ b/src/book/02-system/01-foundations/02-build-system.mdx
@@ -358,10 +358,10 @@ In order to run unit tests, they must first be built. This can be done with:
 
 The `tests` command provides the following subcommands:
 
-| Subcommand | Description                 |
-| ---------- | --------------------------- |
-| list       | List all built tests        |
-| run        | Run all or individual tests |
+| Subcommand | Description                                        |
+| ---------- | -------------------------------------------------- |
+| list       | List all built tests                               |
+| run        | Run all tests (default), or named individual tests |
 
 If you would like to run an individual test (or group of tests), you can pass the `run` subcommand a string and it will only run tests that match the given string.
 Alternatively, `run` will run all built tests if no string is passed.
@@ -374,13 +374,13 @@ For example, if you would like to run all tests with the string 'vision' in thei
 
 The `run` subcommand also accepts the following flags:
 
-| Flag                               | Description                                               |
-| ---------------------------------- | --------------------------------------------------------- |
-| `-V` or `--verbose`                    | Enable verbose output from tests                          |
-| `-VV` or `--extra-verbose`             | Enable more verbose output from tests                     |
-| `-Q` or `--quiet`                      | Make CTest not print to stdout                            |
+| Flag                                   | Description                                              |
+| -------------------------------------- | -------------------------------------------------------- |
+| `-V` or `--verbose`                    | Enable verbose output from tests                         |
+| `-VV` or `--extra-verbose`             | Enable more verbose output from tests                    |
+| `-Q` or `--quiet`                      | Make CTest not print to stdout                           |
 | `-j NUM_JOBS` or `--parallel NUM_JOBS` | Run the tests in parallel using the given number of jobs |
-| --debug                            | Displaying more verbose internals of CTest                |
+| `--debug`                              | Displaying more verbose internals of CTest               |
 
 ## Docker Images
 


### PR DESCRIPTION
Adds documentation for new `./b tests`.
[Preview](https://deploy-preview-98--nubook.netlify.com/system/foundations/build-system#tests)