### PR TITLE
Update webots guide to use Robocup TC fork, add instructions to change mirrors

### DIFF
--- a/src/book/03-guides/02-tools/03-webots.mdx
+++ b/src/book/03-guides/02-tools/03-webots.mdx
@@ -67,11 +67,11 @@ Follow the rest of the steps on this page within Ubuntu.
 
 </details>
 
-Install libraries for cmake, protobuf, eigen, yaml-cpp, and ninja-build:
+Install libraries for cmake, protobuf, eigen, yaml-cpp, ninja-build, and clang-tidy:
 
 ```sh
 sudo apt-get update
-sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen3-dev libyaml-cpp-dev ninja-build
+sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen3-dev libyaml-cpp-dev ninja-build clang-tidy
 ```
 
 ## Install Webots

--- a/src/book/03-guides/02-tools/03-webots.mdx
+++ b/src/book/03-guides/02-tools/03-webots.mdx
@@ -80,12 +80,20 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
    ```sh
    cd ~
-   git clone --branch develop --single-branch --recurse-submodules -j$(nproc) https://github.com/cyberbotics/webots.git
+   git clone --branch release --single-branch --recurse-submodules -j$(nproc) https://github.com/RoboCup-Humanoid-TC/webots.git
    ```
 
-   By using these commands, you'll be on the correct branch (`develop`) and you'll have the required submodules.
+   By using these commands, you'll be on the correct branch (`release`) and you'll have the required submodules.
 
-2. Follow the rest of the instructions on the [Webots GitHub repository](https://github.com/cyberbotics/webots/wiki/Linux-installation). Follow these instructions inside Ubuntu (WSL) if you are a Windows user. See the previous section on how to set this up. The optional dependencies are not required.
+2. Change the download mirrors for Webots depedencies by running the following:
+
+   ```sh
+   cd webots
+   wget https://github.com/NUbots/WebotsDependenciesMirror/raw/master/change-mirrors.patch
+   git apply change-mirrors.patch
+   ```
+
+3. Follow the rest of the instructions on the [Webots GitHub repository](https://github.com/cyberbotics/webots/wiki/Linux-installation). Follow these instructions inside Ubuntu (WSL) if you are a Windows user. See the previous section on how to set this up. The optional dependencies are not required.
 
 ## Get and Build the NUbots Environment
 

--- a/src/book/03-guides/02-tools/03-webots.mdx
+++ b/src/book/03-guides/02-tools/03-webots.mdx
@@ -71,29 +71,38 @@ Install libraries for cmake, protobuf, eigen, yaml-cpp, ninja-build, and clang-t
 
 ```sh
 sudo apt-get update
-sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen3-dev libyaml-cpp-dev ninja-build clang-tidy
+sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen3-dev libyaml-cpp-dev ninja-build clang-tidy python3-dev
 ```
 
 ## Install Webots
 
-1. Open a terminal and swap to your home directory (note that webots should be cloned in your home directory). Then clone the repository:
+1. Open a terminal and swap to your home directory (note that Webots should be cloned in your home directory). Then clone the repository and change into the cloned directory:
 
    ```sh
    cd ~
-   git clone --branch release --single-branch --recurse-submodules -j$(nproc) https://github.com/RoboCup-Humanoid-TC/webots.git
+   git clone --branch nubots-changes --single-branch --recurse-submodules -j$(nproc) https://github.com/NUbots/webots.git
+   cd webots
    ```
 
-   By using these commands, you'll be on the correct branch (`release`) and you'll have the required submodules.
+   By using these commands, you'll be on the correct branch (`nubots-changes`) and you'll have the required submodules.
 
-2. Change the download mirrors for Webots depedencies by running the following:
+2. Install Webots build dependencies:
 
    ```sh
-   cd webots
-   wget https://github.com/NUbots/WebotsDependenciesMirror/raw/master/change-mirrors.patch
-   git apply change-mirrors.patch
+   sudo ./scripts/install/linux_compilation_dependencies.sh
    ```
 
-3. Follow the rest of the instructions on the [Webots GitHub repository](https://github.com/cyberbotics/webots/wiki/Linux-installation). Follow these instructions inside Ubuntu (WSL) if you are a Windows user. See the previous section on how to set this up. The optional dependencies are not required.
+3. Build Webots:
+
+   ```sh
+   make -j$(nproc)
+   ```
+
+4. Add the `WEBOTS_HOME` env variable to your `.bashrc` file:
+
+   ```
+   echo WEBOTS_HOME=/path/to/webots >> ~/.bashrc
+   ```
 
 ## Get and Build the NUbots Environment
 
@@ -104,7 +113,13 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
    cd NUWebots
    ```
 
-2. Configure the codebase by running
+2. Install the python dependencies:
+
+   ```sh
+   pip3 install -r requirements.txt
+   ```
+
+3. Configure the codebase by running
 
    ```sh
    ./b configure
@@ -131,7 +146,7 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
    </details>
 
-3. Build the codebase by running
+4. Build the codebase by running
 
    ```sh
    ./b build

--- a/src/book/03-guides/02-tools/03-webots.mdx
+++ b/src/book/03-guides/02-tools/03-webots.mdx
@@ -101,7 +101,7 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 4. Add the `WEBOTS_HOME` env variable to your `.bashrc` file:
 
    ```
-   echo WEBOTS_HOME=/path/to/webots >> ~/.bashrc
+   echo WEBOTS_HOME=$HOME/webots >> ~/.bashrc
    ```
 
 ## Get and Build the NUbots Environment

--- a/src/book/03-guides/02-tools/03-webots.mdx
+++ b/src/book/03-guides/02-tools/03-webots.mdx
@@ -109,6 +109,7 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 1. Open a terminal. Clone the [NUbots/NUWebots](https://github.com/NUbots/NUWebots/) repository and move into it by running
 
    ```sh
+   cd ~
    git clone https://github.com/NUbots/NUWebots.git
    cd NUWebots
    ```


### PR DESCRIPTION
This changes the Webots guide to install the Robocup TC's fork of Webots, and adds instructions to change the webots download mirrors to use [our version on GitHub](https://github.com/NUbots/WebotsDependenciesMirror).

With this change installs are a lot faster (downloads take minutes instead of hours). 

[Preview](https://deploy-preview-108--nubook.netlify.app/guides/tools/webots-setup#install-webots)