### PR TITLE
Replace `sh` with `bash` in terminal code blocks for proper syntax highlighting

### DIFF
--- a/src/book/02-system/01-foundations/03-continuous-integration.mdx
+++ b/src/book/02-system/01-foundations/03-continuous-integration.mdx
@@ -14,7 +14,7 @@ This CI process works in combination with the [Git Feature Branch workflow](http
 
 1. Developers branch off `master`, creating a new branch with a name of the form `<lastname>/<purpose-of-branch>`. For example:
 
-   ```sh
+   ```bash
    git checkout -b biddulph/ball-detector
    ```
 

--- a/src/book/02-system/02-subsystems/07-logging.mdx
+++ b/src/book/02-system/02-subsystems/07-logging.mdx
@@ -28,7 +28,7 @@ If you provide files in the configuration file **and** files on the command line
 
 You can provide multiple `.nbs` files and they will be played in sequence. For example, the following command will run a role and play back `<nbs-file-a>` followed by `<nbs-file-b>`
 
-```sh
+```bash
 ./b run <role> recordings/<nbs-file-a> recordings/<nbs-file-b>
 ```
 

--- a/src/book/02-system/03-tools/02-nubook.mdx
+++ b/src/book/02-system/03-tools/02-nubook.mdx
@@ -47,7 +47,7 @@ Commands in the next section can be run from the Git Bash terminal, which was do
 1. Install Homebrew by following the instructions at <https://brew.sh/>
 2. Install Git, Node.js and Yarn
 
-   ```sh
+   ```bash
    brew upgrade
    brew install git node && brew install yarn
    ```
@@ -58,26 +58,26 @@ Commands in the next section can be run from the Git Bash terminal, which was do
 
 1. Navigate to the directory where you want to install NUbook
 
-   ```sh
+   ```bash
    cd <path>
    ```
 
 2. Clone the NUbook repository and `cd` into the cloned directory
 
-   ```sh
+   ```bash
    git clone https://github.com/NUbots/NUbook.git
    cd NUbook
    ```
 
 3. Install dependencies
 
-   ```sh
+   ```bash
    yarn
    ```
 
 4. Run the [Gatsby](https://www.gatsbyjs.org/) development server
 
-   ```sh
+   ```bash
    yarn dev
    ```
 
@@ -90,7 +90,7 @@ All additions and edits are done through GitHub pull requests. To add or edit co
 1. Clone the repo, install dependencies, and run the development server as shown in the [Getting Started](#getting-started) section above.
 2. Create a new branch for your changes, in the format `your_surname/short_description_of_change`. An example is below for someone with the surname 'paye'.
 
-   ```sh
+   ```bash
    git checkout -b paye/add_2019_debrief
    ```
 

--- a/src/book/02-system/03-tools/04-nugan.mdx
+++ b/src/book/02-system/03-tools/04-nugan.mdx
@@ -75,25 +75,25 @@ If you are using Windows, we recommend using [Anaconda](https://docs.anaconda.co
 
 On non-Windows OS you can use the provided shell script to install dependencies in Anaconda.
 
-```sh
+```bash
 sh scripts/conda_deps.sh
 ```
 
 To set up with Anaconda on MacOS you can create a new environment with the given environment file
 
-```sh
+```bash
 conda env create -f environment.yml
 ```
 
 In Windows, use the batch file rather than the environment file.
 
-```sh
+```bash
 "./scripts/conda_deps.bat"
 ```
 
 To set up with pip run
 
-```sh
+```bash
 sudo apt install python-pip
 pip3 install setuptools wheel
 pip3 install -r requirements.txt
@@ -115,7 +115,7 @@ Note that semi-synthetic images and segmentation images should have matched nami
 
 Start the Visdom server to see a visual representation of the training.
 
-```sh
+```bash
 python -m visdom.server
 ```
 
@@ -123,13 +123,13 @@ Open Visdom in your browser at [http://localhost:8097/](http://localhost:8097/).
 
 Open a new window. In Windows, run
 
-```sh
+```bash
 "scripts/train.bat" <GPU_ID> <BATCH_SIZE> <NAME> <DATAROOT> <CONT> <EPOCHCOUNT>
 ```
 
 In other OS, such as Linux, run
 
-```sh
+```bash
 sh scripts/train.sh <GPU_ID> <BATCH_SIZE> <NAME> <DATAROOT> <CONT> <EPOCHCOUNT>
 ```
 
@@ -160,13 +160,13 @@ Testing requires testA, testA_seg, and testB folders.
 
 In Windows run
 
-```sh
+```bash
 "scripts/test.bat" <GPU_ID> <NAME> <DATAROOT>
 ```
 
 In other OS, such as Linux, run
 
-```sh
+```bash
 sh scripts/test.sh <GPU_ID> <NAME> <DATAROOT>
 ```
 
@@ -180,13 +180,13 @@ Generating requires a single generateA folder that contains Blender semi-synthet
 
 In Windows run
 
-```sh
+```bash
 "scripts/generate.bat" <GPU_ID> <NAME> <DATAROOT>
 ```
 
 In other OS, such as Linux, run
 
-```sh
+```bash
 sh scripts/generate.sh <GPU_ID> <NAME> <DATAROOT>
 ```
 

--- a/src/book/03-guides/02-tools/03-webots.mdx
+++ b/src/book/03-guides/02-tools/03-webots.mdx
@@ -24,7 +24,7 @@ slug: /guides/tools/webots-setup
 
    - To prevent having to set the DISPLAY environment variable every time, run the following command in Ubuntu:
 
-     ```sh
+     ```bash
      echo 'export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '\''{print $2; exit;}'\''):0.0' >> ~/.bashrc
      ```
 
@@ -36,7 +36,7 @@ slug: /guides/tools/webots-setup
 
 3. In Ubuntu run
 
-   ```sh
+   ```bash
    sudo apt-get update
    sudo apt-get install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxkbcommon-x11-0 libxkbcommon0
    ```
@@ -69,7 +69,7 @@ Follow the rest of the steps on this page within Ubuntu.
 
 Install libraries for cmake, protobuf, eigen, yaml-cpp, ninja-build, and clang-tidy:
 
-```sh
+```bash
 sudo apt-get update
 sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen3-dev libyaml-cpp-dev ninja-build clang-tidy python3-dev libjpeg9-dev
 ```
@@ -78,7 +78,7 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 1. Open a terminal and swap to your home directory (note that Webots should be cloned in your home directory). Then clone the repository and change into the cloned directory:
 
-   ```sh
+   ```bash
    cd ~
    git clone --branch nubots-changes --single-branch --recurse-submodules -j$(nproc) https://github.com/NUbots/webots.git
    cd webots
@@ -88,13 +88,13 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 2. Install Webots build dependencies:
 
-   ```sh
+   ```bash
    sudo ./scripts/install/linux_compilation_dependencies.sh
    ```
 
 3. Build Webots:
 
-   ```sh
+   ```bash
    make -j$(nproc)
    ```
 
@@ -106,14 +106,14 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 5. Install dependencies for the referee:
 
-   ```sh
+   ```bash
    cd ~/webots/projects/samples/contests/robocup/controllers/referee
    pip3 install -r requirements.txt
    ```
 
 6. Build the Robocup controllers:
 
-   ```sh
+   ```bash
    cd ~/webots/projects/samples/contests/robocup
    WEBOTS_HOME=$HOME/webots make -j$(nproc)
    ```
@@ -122,20 +122,20 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 1. Install the ant build tool:
 
-   ```sh
+   ```bash
    sudo apt-get install ant default-jdk
    ```
 
 2. Clone the Robocup TC GameController repo:
 
-   ```sh
+   ```bash
    cd ~
    git clone https://github.com/RoboCup-Humanoid-TC/GameController.git
    ```
 
 3. Change into the cloned directory and build the GameController:
 
-   ```sh
+   ```bash
    cd GameController
    ant
    ```
@@ -144,7 +144,7 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 1. Open a terminal. Clone the [NUbots/NUWebots](https://github.com/NUbots/NUWebots/) repository and move into it by running
 
-   ```sh
+   ```bash
    cd ~
    git clone https://github.com/NUbots/NUWebots.git
    cd NUWebots
@@ -152,13 +152,13 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 2. Install the python dependencies:
 
-   ```sh
+   ```bash
    pip3 install -r requirements.txt
    ```
 
 3. Configure the codebase by running
 
-   ```sh
+   ```bash
    ./b configure
    ```
 
@@ -167,7 +167,7 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
    <summary> Optional Flags </summary>
    We can configure with several optional flags as follows:
 
-   ```sh
+   ```bash
    ./b configure [-i] [-- <flags>]
    ```
 
@@ -185,7 +185,7 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 4. Build the codebase by running
 
-   ```sh
+   ```bash
    ./b build
    ```
 
@@ -193,13 +193,13 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 1. Navigate to the Webots folder
 
-   ```sh
+   ```bash
    cd ~/webots
    ```
 
 2. Launch Webots by running
 
-   ```sh
+   ```bash
    ./webots
    ```
 
@@ -213,7 +213,7 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 1. Find your primary local IP address by running the following.
 
-   ```sh
+   ```bash
    hostname -I
    ```
 
@@ -221,13 +221,13 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 2. Set the `GAME_CONTROLLER_UDP_FILTER` env variable to your local IP address from step 1, to ensure your instance of GameController is not affected by other instances of GameController on the network.
 
-   ```sh
+   ```bash
    export GAME_CONTROLLER_UDP_FILTER=<IP_ADDRESS> # replace <IP_ADDRESS> with your IP address from step 1
    ```
 
 3. Run the following to open Webots with the Robocup world and the GameController:
 
-   ```sh
+   ```bash
    JAVA_HOME=/usr/lib/jvm/default-java WEBOTS_HOME=$HOME/webots GAME_CONTROLLER_HOME=$HOME/GameController ~/webots/webots ~/webots/projects/samples/contests/robocup/worlds/robocup.wbt
    ```
 
@@ -235,7 +235,7 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
    Sometimes closing Webots doesn't properly close the GameController subprocess. If this happens you'll get an error about GameController when you next launch Webots. To fix, run the following command which terminates the GameController process, then start Webots again:
 
-   ```sh
+   ```bash
    kill -9 $(pgrep -fi GameControllerSimulator.jar)
    ```
 
@@ -245,7 +245,7 @@ sudo apt-get install cmake-curses-gui libprotobuf-dev protobuf-compiler libeigen
 
 From the root of the NUWebots repository run
 
-```sh
+```bash
 ./b controller generate <name of controller>
 ```
 

--- a/src/book/03-guides/03-hardware/02-flashing.mdx
+++ b/src/book/03-guides/03-hardware/02-flashing.mdx
@@ -15,7 +15,7 @@ To install Arch Linux (our OS of choice) on to a robot perform the following ins
    - Find the USB drive in your system. This will vary from one system to another and choosing the wrong drive will cause irreversible data loss.
      - Use `sudo fdisk -l`, or the `Disks` GUI program to find your USB drive. It will probably be `/dev/sdX`, where `X` is a letter of the alphabet.
    - Burn the Arch Linux ISO you just downloaded to the USB drive (in this example we are using `/dev/sdb`)
-   - ```sh
+   - ```bash
      sudo dd bs=4M if=~/Downloads/archlinux-2019.11.01-x86_64.iso of=/dev/sdb status=progress oflag=sync
      ```
 
@@ -48,20 +48,20 @@ To install Arch Linux (our OS of choice) on to a robot perform the following ins
 
 5. Download the installation script [https://git.io/JeWaF](https://git.io/JeWaF) and make sure the script is executable
 
-   - ```sh
+   - ```bash
      curl -L https://git.io/JeWaF -o ./arch_install.sh
      chmod +x ./arch_install.sh
      ```
    - The installation script is located in the NUbots repository at [doc/ArchInstall/arch_install.sh](https://github.com/NUbots/NUbots/blob/master/doc/ArchInstall/arch_install.sh)
 
 6. Execute the script and follow the instructions
-   - ```sh
+   - ```bash
      ./arch_install.sh
      ```
 
 The installation script will end by downloading a secondary script and providing you with a command that you must run
 
-```sh
+```bash
 ROBOT_NUMBER=<N> arch-chroot /mnt ./arch-chroot_install.sh
 ```
 
@@ -71,7 +71,7 @@ Substitute `<N>` with the number of the robot that you are building. This will i
 
 The secondary script assumes that the network interfaces are named `eth0` for ethernet and `wlan0` for WiFi. If you _know_ this is not the case then execute the script as follows
 
-```sh
+```bash
 ROBOT_NUMBER=<N> \
 ETHERNET_INTERFACE=IF_NAME \
 WIFI_INTERFACE=IF_NAME \
@@ -82,7 +82,7 @@ arch-chroot /mnt ./arch-chroot_install.sh
 
 Finally, once that script has finished, you must run one more command.
 
-```sh
+```bash
 /mnt/arch-post_install.sh
 ```
 
@@ -118,7 +118,7 @@ These 5 files need to be both renamed (replacing `eth0` or `wlan0` with the new 
 
 Next, correct the `wpa_supplicant` service by running
 
-```sh
+```bash
 sudo systemctl disable wpa_supplicant@wlan0
 sudo systemctl enable wpa_supplicant@new_interface
 ```
@@ -131,7 +131,7 @@ Once these files have been fixed, reboot by typing `sudo systemctl reboot` and t
 
 To set up the WiFi interface you first need to know the name of the interface. To find this, run
 
-```sh
+```bash
 ip link
 ```
 
@@ -143,20 +143,20 @@ The rest of these instructions assume a network using WPA2 (like the network use
 
 1. Make sure the `wpa_supplicant` configuration directory exists
 
-   - ```sh
+   - ```bash
      mkdir -p /etc/wpa_supplicant
      ```
 
 2. Setup the network configuration
 
-   - ```sh
+   - ```bash
      wpa_passphrase <Network SSID> <Network Passphrase> > /etc/wpa_supplicant/wpa_supplicant-<WiFi Interface>.conf
      ```
    - Be sure to replace `<Network SSID>` with the SSID of the wireless network to connect to (either `epsilon-x` or `epsilon-z` in the lab), `<Network Passphrase>` with the password for the network (ask someone for the lab password if you don't know it), and `<WiFi Interface>` with the name of the interface found earlier.
 
 3. Now start all of the necessary services
 
-   - ```sh
+   - ```bash
      systemctl start dhcpcd.service
      systemctl start wpa_supplicant.service
      systemctl start wpa_supplicant@<Wifi Interface>.service

--- a/src/book/03-guides/04-general/01-git.mdx
+++ b/src/book/03-guides/04-general/01-git.mdx
@@ -22,7 +22,7 @@ In the terminal, change directory to the location where the repository is cloned
 
 If you are working within an existing project, then you need to find out which branch the work is on. To list the branches, use the command `git branch -r`. When you have found the branch you want to push to, swap to it using the following command:
 
-```sh
+```bash
 git checkout <branch name>
 ```
 

--- a/src/book/03-guides/04-general/02-troubleshooting.mdx
+++ b/src/book/03-guides/04-general/02-troubleshooting.mdx
@@ -25,7 +25,7 @@ Team mentors **Alex Biddulph** and **Trent Houliston** can help with most parts 
 
 If your compiler can't find `FileWatcher.h` as in the following error:
 
-```sh
+```bash
 nuclear/roles/firmwareinstaller.cpp:3:10: fatal error: extension/FileWatcher/src/FileWatcher.h: No such file or directory
     3 | #include "extension/FileWatcher/src/FileWatcher.h"
       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -92,20 +92,20 @@ TODO
 ## NUbook
 
 <Alert type="info">
-  The commands shown below should be run from the NUbook root folder, unless otherwise stated.  
+  The commands shown below should be run from the NUbook root folder, unless otherwise stated.
 </Alert>
 
 ### Why is my newly added page not showing up?
 
 When you add a new page, you should remove the Gatsby `.cache` and `public` folders, by running:
 
-```sh
+```bash
 rm -rf .cache public
 ```
 
 And then try building again:
 
-```sh
+```bash
 yarn dev
 ```
 
@@ -113,13 +113,13 @@ yarn dev
 
 Usually this happens when there is a problem with one or more packages in the `node_modules` folder. Try deleting `node_modules` and running `yarn` to reinstall dependencies:
 
-```sh
+```bash
 rm -rf node_modules && yarn
 ```
 
 Then try building again:
 
-```sh
+```bash
 yarn dev
 ```
 
@@ -129,7 +129,7 @@ If a page you have added or changed is not formatted correctly, your changes may
 
 To fix this, run:
 
-```sh
+```bash
 yarn format --fix
 ```
 
@@ -139,12 +139,12 @@ First, make sure you have saved the file, then refresh NUbook in the browser to 
 
 If you have created a new page or added a new image, you may need to remove the `.cache` and `public` folders. To do so, run:
 
-```sh
+```bash
 rm -rf .cache public
 ```
 
 And then try building again:
 
-```sh
+```bash
 yarn dev
 ```


### PR DESCRIPTION
This will correctly highlight comments, command names, and other shell syntax.