### PR TITLE
Fix bash consistency

### DIFF
--- a/src/book/03-guides/01-main-codebase/01-getting-started.mdx
+++ b/src/book/03-guides/01-main-codebase/01-getting-started.mdx
@@ -118,11 +118,11 @@ To install on Ubuntu, use the [official Docker instructions](https://docs.docker
 
    - Open Windows Powershell in administrator mode.
    - Run the following to install WSL:
-     ```
+     ```bash
      dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
      ```
    - Run the following to enable the Virtual Machine Platform feature needed for WSL:
-     ```
+     ```bash
      dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart
      ```
    - Restart your computer.
@@ -275,7 +275,7 @@ If you are following the example, run `./b run keyboardwalkfake`. If you are on 
 
 Windows and MacOS users who want to connect to NUsight will need to set up the docker network and run
 
-```
+```bash
 ./b run keyboardwalkfake --network nuclearnet
 ```
 

--- a/src/book/03-guides/02-tools/02-gazebo-install.mdx
+++ b/src/book/03-guides/02-tools/02-gazebo-install.mdx
@@ -23,7 +23,7 @@ Follow the instructions to setup Ubuntu with WSL [here](/guides/main/getting-sta
 1. Install [Gazebo](http://gazebosim.org/tutorials?cat=install&tut=install_ubuntu&ver=9.0) (version 9 last tested) using Ubuntu.
 
 2. Install Gazebo dev libaries.
-   ```
+   ```bash
    sudo apt-get install libgazebo9-dev
    ```
 
@@ -36,12 +36,12 @@ Download and install VcXsrv [here](https://sourceforge.net/projects/vcxsrv/).
 ## Running NUbots simulation
 
 1. Clone this repo.
-   ```
+   ```bash
    git clone https://github.com/NUbots/Gazebo.git
    ```
 2. Install the plugin.
 
-   ```
+   ```bash
    cd gazebo
    sudo bash ./install_plugin.sh
    ```
@@ -52,7 +52,7 @@ Download and install VcXsrv [here](https://sourceforge.net/projects/vcxsrv/).
 
 3. Setup WSL to connect with VcXsrv server.
 
-   ```
+   ```bash
    export GAZEBO_IP=127.0.0.1
    export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}'):0
    export LIBGL_ALWAYS_INDIRECT=0
@@ -67,7 +67,7 @@ Download and install VcXsrv [here](https://sourceforge.net/projects/vcxsrv/).
    ![Xlaunch settings](./images/extra-settings.png 'Extra settings')
 
 7. Run the plugin.
-   ```
+   ```bash
    sudo bash ./run_plugin.sh
    ```
 

--- a/src/book/03-guides/02-tools/04-visualmesh.mdx
+++ b/src/book/03-guides/02-tools/04-visualmesh.mdx
@@ -21,7 +21,6 @@ Python 3.8.5
 pip 20.0.2 from /usr/lib/python3/dist-packages/pip (python 3.8)
 git version 2.25.1
 Docker version 20.10.3, build 48d30b5
-
 ```
 
 <details>


### PR DESCRIPTION
Some of our guides didn't have the "bash" tag for code blocks which affects syntax highlighting

[Preview](https://deploy-preview-154--nubook.netlify.app/guides/main/getting-started)