### PR TITLE
Updated "Setting Up Webots" page in the section: Prerequisites - Windows

### DIFF
--- a/src/book/03-guides/02-tools/03-webots.mdx
+++ b/src/book/03-guides/02-tools/03-webots.mdx
@@ -47,6 +47,12 @@ You will need XLaunch running every time you want to run Webots.
 
 </Alert>
 
+<Alert type='info'>
+
+If Webots crashes with an error, head back into the XLaunch display settings and choose "One large window" instead of "Multiple windows".
+
+</Alert>
+
 Follow the rest of the steps on this page within Ubuntu.
 
 </details>


### PR DESCRIPTION
Added a potential fix if Webots crashes with an error on Windows OS