### PR TITLE
Add `gap` property to `Grid` component

### DIFF
--- a/src/book/02-system/03-tools/02-nubook.mdx
+++ b/src/book/02-system/03-tools/02-nubook.mdx
@@ -236,10 +236,10 @@ Here are some resources for learning how to draw graphs with Graphviz:
 
 You can show content such as images, code, and math equations side-by-side in a grid.
 
-The following example shows four images in a 2x2 grid with a caption:
+The following example shows four images in a 2x2 grid with large spacing between items and a caption:
 
 ```md
-<Grid columns='1fr 1fr' rows="1fr 1fr" caption="Some lovely pets">
+<Grid columns='1fr 1fr' rows="1fr 1fr" gap="large" caption="Some lovely pets">
 
 ![Bird](https://source.unsplash.com/featured/1600x900/?bird,1 'Bird')
 ![Cat](https://source.unsplash.com/featured/1600x900/?cat,1 'Cat')
@@ -250,6 +250,8 @@ The following example shows four images in a 2x2 grid with a caption:
 ```
 
 The [columns](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns) and [rows](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns) are specified using CSS grid syntax. `fr` is a fractional unit that specifies a fraction of the total available space (width for columns, and height for rows). `columns='1fr 1fr'` creates two columns of equal width, while `rows='1fr 1fr'` creates two rows of equal height.
+
+The `gap` property sets the spacing between items in the grid, and can be one of `none` (no gap), `small` (the default), `medium`, `large`, or `extra-large`.
 
 ### Images in Tabs
 

--- a/src/book/kitchen-sink/05-images.mdx
+++ b/src/book/kitchen-sink/05-images.mdx
@@ -40,6 +40,41 @@ hidden: true
 
 </Grid>
 
+### Different grid gaps
+
+#### `gap="medium"`
+
+<Grid columns='1fr 1fr' rows="1fr 1fr" gap="medium" caption="Some possible pets" seamless>
+
+![Bird](https://source.unsplash.com/featured/960x540/?bird,1 'Bird')
+![Cat](https://source.unsplash.com/featured/960x540/?cat,1 'Cat')
+![Dog](https://source.unsplash.com/featured/960x540/?dog,1 'Dog')
+![Turtle](https://source.unsplash.com/featured/960x540/?turtle,1 'Turtle')
+
+</Grid>
+
+#### `gap="large"`
+
+<Grid columns='1fr 1fr' rows="1fr 1fr" gap="large" caption="Some possible pets" seamless>
+
+![Bird](https://source.unsplash.com/featured/960x540/?bird,1 'Bird')
+![Cat](https://source.unsplash.com/featured/960x540/?cat,1 'Cat')
+![Dog](https://source.unsplash.com/featured/960x540/?dog,1 'Dog')
+![Turtle](https://source.unsplash.com/featured/960x540/?turtle,1 'Turtle')
+
+</Grid>
+
+#### `gap="extra-large"`
+
+<Grid columns='1fr 1fr' rows="1fr 1fr" gap="extra-large" caption="Some possible pets" seamless>
+
+![Bird](https://source.unsplash.com/featured/960x540/?bird,1 'Bird')
+![Cat](https://source.unsplash.com/featured/960x540/?cat,1 'Cat')
+![Dog](https://source.unsplash.com/featured/960x540/?dog,1 'Dog')
+![Turtle](https://source.unsplash.com/featured/960x540/?turtle,1 'Turtle')
+
+</Grid>
+
 ## Images in tabs
 
 <TabbedImages>

--- a/src/book/kitchen-sink/05-images.mdx
+++ b/src/book/kitchen-sink/05-images.mdx
@@ -44,7 +44,7 @@ hidden: true
 
 #### `gap="medium"`
 
-<Grid columns='1fr 1fr' rows="1fr 1fr" gap="medium" caption="Some possible pets" seamless>
+<Grid columns='1fr 1fr' rows="1fr 1fr" gap="medium" caption="Some possible pets">
 
 ![Bird](https://source.unsplash.com/featured/960x540/?bird,1 'Bird')
 ![Cat](https://source.unsplash.com/featured/960x540/?cat,1 'Cat')
@@ -55,7 +55,7 @@ hidden: true
 
 #### `gap="large"`
 
-<Grid columns='1fr 1fr' rows="1fr 1fr" gap="large" caption="Some possible pets" seamless>
+<Grid columns='1fr 1fr' rows="1fr 1fr" gap="large" caption="Some possible pets">
 
 ![Bird](https://source.unsplash.com/featured/960x540/?bird,1 'Bird')
 ![Cat](https://source.unsplash.com/featured/960x540/?cat,1 'Cat')
@@ -66,7 +66,7 @@ hidden: true
 
 #### `gap="extra-large"`
 
-<Grid columns='1fr 1fr' rows="1fr 1fr" gap="extra-large" caption="Some possible pets" seamless>
+<Grid columns='1fr 1fr' rows="1fr 1fr" gap="extra-large" caption="Some possible pets">
 
 ![Bird](https://source.unsplash.com/featured/960x540/?bird,1 'Bird')
 ![Cat](https://source.unsplash.com/featured/960x540/?cat,1 'Cat')

--- a/src/components/markdown/grid/grid.jsx
+++ b/src/components/markdown/grid/grid.jsx
@@ -27,13 +27,14 @@ const Grid = ({ children, rows, columns, gap, caption, seamless }) => {
     }
   `
   return (
-    <figure
-      className={`${style.grid} ${gapStyles[gap] ?? style.gridGapSmall} ${
-        seamless ? style.gridSeamless : ''
-      } `}
-    >
+    <figure className={`${style.grid} ${seamless ? style.gridSeamless : ''} `}>
       <style dangerouslySetInnerHTML={{ __html: styleContent }}></style>
-      <div id={id} className={style.gridContent}>
+      <div
+        id={id}
+        className={`${style.gridContent}  ${
+          gapStyles[gap] ?? style.gridGapSmall
+        }`}
+      >
         {children}
       </div>
       {caption && (

--- a/src/components/markdown/grid/grid.jsx
+++ b/src/components/markdown/grid/grid.jsx
@@ -8,7 +8,15 @@ function nextId() {
   return currentId++
 }
 
-const Grid = ({ children, rows, columns, caption, seamless }) => {
+const gapStyles = {
+  'none': style.gridGapNone,
+  'small': style.gridGapSmall,
+  'medium': style.gridGapMedium,
+  'large': style.gridGapLarge,
+  'extra-large': style.gridGapExtraLarge,
+}
+
+const Grid = ({ children, rows, columns, gap, caption, seamless }) => {
   const id = 'grid-' + nextId()
   const styleContent = `
     @media (min-width: 768px) {
@@ -19,7 +27,11 @@ const Grid = ({ children, rows, columns, caption, seamless }) => {
     }
   `
   return (
-    <figure className={`${style.grid} ${seamless ? style.gridSeamless : ''} `}>
+    <figure
+      className={`${style.grid} ${gapStyles[gap] ?? style.gridGapSmall} ${
+        seamless ? style.gridSeamless : ''
+      } `}
+    >
       <style dangerouslySetInnerHTML={{ __html: styleContent }}></style>
       <div id={id} className={style.gridContent}>
         {children}
@@ -34,9 +46,14 @@ const Grid = ({ children, rows, columns, caption, seamless }) => {
 Grid.propTypes = {
   rows: PropTypes.string,
   columns: PropTypes.string,
+  gap: PropTypes.string,
   caption: PropTypes.string,
   seamless: PropTypes.bool,
   children: PropTypes.node,
+}
+
+Grid.defaultProps = {
+  gap: 'small',
 }
 
 export default Grid

--- a/src/components/markdown/grid/grid.module.css
+++ b/src/components/markdown/grid/grid.module.css
@@ -12,8 +12,31 @@
 
 .gridContent {
   display: grid;
+}
+
+.gridGapNone {
+  grid-column-gap: 0;
+  grid-row-gap: 0;
+}
+
+.gridGapSmall {
   grid-column-gap: 8px;
   grid-row-gap: 8px;
+}
+
+.gridGapMedium {
+  grid-column-gap: 16px;
+  grid-row-gap: 16px;
+}
+
+.gridGapLarge {
+  grid-column-gap: 24px;
+  grid-row-gap: 24px;
+}
+
+.gridGapExtraLarge {
+  grid-column-gap: 32px;
+  grid-row-gap: 32px;
 }
 
 .gridContent > * {


### PR DESCRIPTION
Allows for customising the spacing between items in the grid. Useful for things like [maths equations](https://github.com/NUbots/NUbook/pull/201).

Preview: https://deploy-preview-203--nubook.netlify.app/kitchen-sink/images#different-grid-gaps
Documentation: https://deploy-preview-203--nubook.netlify.app/system/tools/nubook#content-in-grids