### PR TITLE
Add contributor list to contributions section

### DIFF
--- a/src/components/contributions/contributions.jsx
+++ b/src/components/contributions/contributions.jsx
@@ -10,12 +10,12 @@ const Contributions = ({ date, url, mdxPath, contributors }) => {
   const editLink = `https://github.com/NUbots/NUbook/edit/main/${mdxPath}`
   return (
     <div className='text-sm text-secondary dark:text-secondary-inverted mb-6 border-t-2 border-b-2 border-gray-200 dark:border-gray-800 py-2 flex items-center'>
-      <div className='flex-grow flex gap-x-2'>
+      <div className='flex-grow flex gap-x-1 flex-wrap h-7 overflow-hidden'>
         {contributors.map((contributor, i) => {
           return (
-            <a className='w-7 h-auto' key={i} href={contributor.url}>
+            <a key={i} href={contributor.url}>
               <img
-                className='rounded-full'
+                className='h-7 rounded-full'
                 title={contributor.name}
                 src={contributor.avatar}
               />
@@ -23,7 +23,7 @@ const Contributions = ({ date, url, mdxPath, contributors }) => {
           )
         })}
       </div>
-      <div className='pr-3 capitalize inline-block'>
+      <div className='pr-3 capitalize inline-block whitespace-nowrap ml-1'>
         <span className='hidden lg:inline'>Last</span> updated{' '}
         <a
           href={url}

--- a/src/components/contributions/contributions.jsx
+++ b/src/components/contributions/contributions.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import EditIcon from './edit-icon.svg'
 
-const Contributions = ({ date, url, mdxPath }) => {
+const Contributions = ({ date, url, mdxPath, contributors }) => {
   const lastUpdated = new Date(date).toLocaleString('en-AU', {
     dateStyle: 'long',
   })
@@ -39,6 +39,13 @@ Contributions.propTypes = {
   date: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   mdxPath: PropTypes.string.isRequired,
+  contributors: PropTypes.arrayOf(
+    PropTypes.shape({
+      avatar: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ).isRequired,
 }
 
 export default Contributions

--- a/src/components/contributions/contributions.jsx
+++ b/src/components/contributions/contributions.jsx
@@ -6,11 +6,24 @@ const Contributions = ({ date, url, mdxPath, contributors }) => {
   const lastUpdated = new Date(date).toLocaleString('en-AU', {
     dateStyle: 'long',
   })
+
   const editLink = `https://github.com/NUbots/NUbook/edit/main/${mdxPath}`
   return (
-    <div className='text-sm text-secondary dark:text-secondary-inverted mb-6 border-t-2 border-b-2 border-gray-200 dark:border-gray-800 py-3 flex'>
-      <div className='flex-grow'></div>
-      <div className='pr-3 capitalize'>
+    <div className='text-sm text-secondary dark:text-secondary-inverted mb-6 border-t-2 border-b-2 border-gray-200 dark:border-gray-800 py-2 flex items-center'>
+      <div className='flex-grow flex gap-x-2'>
+        {contributors.map((contributor, i) => {
+          return (
+            <a className='w-7 h-auto' key={i} href={contributor.url}>
+              <img
+                className='rounded-full'
+                title={contributor.name}
+                src={contributor.avatar}
+              />
+            </a>
+          )
+        })}
+      </div>
+      <div className='pr-3 capitalize inline-block'>
         <span className='hidden lg:inline'>Last</span> updated{' '}
         <a
           href={url}

--- a/src/components/contributions/contributions.jsx
+++ b/src/components/contributions/contributions.jsx
@@ -4,7 +4,7 @@ import EditIcon from './edit-icon.svg'
 
 const Contributions = ({ date, url, mdxPath, contributors }) => {
   const lastUpdated = new Date(date).toLocaleString('en-AU', {
-    dateStyle: 'long',
+    dateStyle: 'medium',
   })
 
   const editLink = `https://github.com/NUbots/NUbook/edit/main/${mdxPath}`

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -11,7 +11,7 @@ import TableOfContents from './table-of-contents/table-of-contents'
 import Footer from './footer/footer'
 import Contributions from './contributions/contributions'
 
-const Layout = ({ children, data, pageContext, commit }) => {
+const Layout = ({ children, data, pageContext, commit, contributors }) => {
   const {
     section: sectionTitle,
     chapter: chapterTitle,
@@ -80,6 +80,7 @@ const Layout = ({ children, data, pageContext, commit }) => {
                   description={description}
                 />
                 <Contributions
+                  contributors={contributors}
                   date={commit.author.date}
                   url={commit.url}
                   mdxPath={mdxPath}
@@ -126,6 +127,7 @@ Layout.propTypes = {
     }).isRequired,
     url: PropTypes.string.isRequired,
   }).isRequired,
+  contributors: PropTypes.array.isRequired,
 }
 
 export default Layout

--- a/src/components/page-template.jsx
+++ b/src/components/page-template.jsx
@@ -6,9 +6,20 @@ import { MDXRenderer } from 'gatsby-plugin-mdx'
 import Layout from './layout'
 
 const PageTemplate = (props) => {
-  const commit = props.data.github.repository.object.history.nodes[0]
+  const commits = props.data.github.repository.object.history.nodes
+  const commit = commits[0]
+
+  const contributors = commits.filter(
+    (v, i, a) => a.findIndex((t) => t.author.user.id === v.author.user.id) === i
+  )
+
   return (
-    <Layout pageContext={props.pageContext} data={props.data} commit={commit}>
+    <Layout
+      pageContext={props.pageContext}
+      data={props.data}
+      commit={commit}
+      contributors={contributors}
+    >
       <MDXRenderer>{props.data.mdx.body}</MDXRenderer>
     </Layout>
   )

--- a/src/components/page-template.jsx
+++ b/src/components/page-template.jsx
@@ -55,6 +55,12 @@ export const query = graphql`
               nodes {
                 author {
                   date
+                  name
+                  avatarUrl
+                  user {
+                    url
+                    id
+                  }
                 }
                 url
               }

--- a/src/components/page-template.jsx
+++ b/src/components/page-template.jsx
@@ -9,9 +9,18 @@ const PageTemplate = (props) => {
   const commits = props.data.github.repository.object.history.nodes
   const commit = commits[0]
 
-  const contributors = commits.filter(
+  const unique = commits.filter(
     (v, i, a) => a.findIndex((t) => t.author.user.id === v.author.user.id) === i
   )
+
+  const contributors = []
+  unique.forEach((commit) => {
+    contributors.push({
+      avatar: commit.author.avatarUrl,
+      url: commit.author.user.url,
+      name: commit.author.name,
+    })
+  })
 
   return (
     <Layout


### PR DESCRIPTION
Addresses #192 

- Adds list of page contributors to the contributions/last updated section.

The name tool-tips currently use the `title` attribute as I had trouble implementing the tool-tips shown in the [mock-up](https://github.com/NUbots/NUbook/issues/192#issue-1022549762).

[Preview](https://deploy-preview-204--nubook.netlify.app/system/foundations/build-system)