### PR TITLE
Fix contributors component accessing undefined properties on new pages

### DIFF
--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -79,12 +79,14 @@ const Layout = ({ children, data, pageContext, commit, contributors }) => {
                   title={title}
                   description={description}
                 />
-                <Contributions
-                  contributors={contributors}
-                  date={commit.author.date}
-                  url={commit.url}
-                  mdxPath={mdxPath}
-                />
+                {commit && (
+                  <Contributions
+                    contributors={contributors}
+                    date={commit.author.date}
+                    url={commit.url}
+                    mdxPath={mdxPath}
+                  />
+                )}
                 <Markdown>{children}</Markdown>
               </article>
               <ArticleNavigation next={next} previous={previous} />


### PR DESCRIPTION
Ensures that the contributor component only renders when a commit is returned by the GitHub API. 

This prevents the contributor component from accessing undefined properties on new or renamed pages that don't exist on the main branch (see [discussion](https://github.com/NUbots/NUbook/pull/183#issuecomment-1013558037)).