### PR TITLE
Ensure files in `build-plugins/` and `static/` are formatted

### DIFF
--- a/build-plugins/remark-absolute-image-src.js
+++ b/build-plugins/remark-absolute-image-src.js
@@ -16,7 +16,7 @@ module.exports = function mdxAbsoluteImageSrc({
   markdownNode,
   getNode,
 }) {
-  visit(markdownAST, 'image', image => {
+  visit(markdownAST, 'image', (image) => {
     // Make sure the parent node has dir (e.g. the image is a top-level node so its parent is the file)
     if (!markdownNode.parent || !getNode(markdownNode.parent).dir) {
       return

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "dev": "gatsby develop",
     "clean": "rimraf .cache/ public/",
     "lint": "eslint \"src/**/*.{jsx,js}\" \"*.js\" && stylelint \"src/**/*.css\"",
-    "format": "stylelint \"src/**/*.css\" --fix && prettier --write \"src/**/*.{css,jsx,js,mdx}\" \"*.js\"",
-    "format:check": "prettier --check \"src/**/*.{css,jsx,js,mdx}\" \"*.js\""
+    "format": "stylelint \"src/**/*.css\" --fix && prettier --write \"*.js\" \"src/**/*.{css,jsx,js,mdx}\" \"build-plugins/**/*.js\"",
+    "format:check": "prettier --check \"*.js\" \"src/**/*.{css,jsx,js,mdx}\" \"build-plugins/**/*.js\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "dev": "gatsby develop",
     "clean": "rimraf .cache/ public/",
     "lint": "eslint \"src/**/*.{jsx,js}\" \"*.js\" && stylelint \"src/**/*.css\"",
-    "format": "stylelint \"src/**/*.css\" --fix && prettier --write \"*.js\" \"src/**/*.{css,jsx,js,mdx}\" \"build-plugins/**/*.js\"",
-    "format:check": "prettier --check \"*.js\" \"src/**/*.{css,jsx,js,mdx}\" \"build-plugins/**/*.js\""
+    "format": "stylelint \"src/**/*.css\" --fix && prettier --write \"*.js\" \"src/**/*.{css,jsx,js,mdx}\" \"build-plugins/**/*.js\" \"static/**/*.js\"",
+    "format:check": "prettier --check \"*.js\" \"src/**/*.{css,jsx,js,mdx}\" \"build-plugins/**/*.js\" \"static/**/*.js\""
   },
   "repository": {
     "type": "git",

--- a/static/algolia-search.js
+++ b/static/algolia-search.js
@@ -25,8 +25,8 @@ loadAlgoliaScript().then(() => {
     // Update the URL on hits to have the current origin,
     // to support local development and deploy previews
     // (they point to the production site otherwise)
-    transformData: function(hits) {
-      hits.forEach(hit => {
+    transformData: function (hits) {
+      hits.forEach((hit) => {
         const { origin } = new URL(hit.url)
         hit.url = hit.url.replace(origin, window.location.origin)
       })
@@ -35,7 +35,7 @@ loadAlgoliaScript().then(() => {
 })
 
 // Add support for the / keyboard shortcut
-window.addEventListener('keydown', event => {
+window.addEventListener('keydown', (event) => {
   // Don't do anything if an input is focused
   if (
     document.activeElement instanceof HTMLInputElement ||


### PR DESCRIPTION
Currently files in `build-plugins/` and `static/` are not checked for formatting with `yarn format:check`. This PR remedies that, and fixes a formatting issue in two of the files.