### PR TITLE
Fix the Code of Conduct Links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 ## Code of Conduct
 
-NUbook is a project of the NUbots team at the University of Newcastle, Australia. The team, all external contributors, and all users of its projects must comply with the [University's Code of Conduct](https://policies.newcastle.edu.au/document/view-current.php?id=204).
+NUbook is a project of the NUbots team at the University of Newcastle, Australia. The team, all external contributors, and all users of its projects must comply with the [University's Code of Conduct](https://www.newcastle.edu.au/__data/assets/pdf_file/0003/85701/code-of-conduct.pdf).

--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -26,7 +26,7 @@ const Footer = () => (
         <div>
           <a
             className='hover:text-gray-800 focus:text-gray-800 dark:hover:text-gray-300 dark:focus:text-gray-300'
-            href='https://policies.newcastle.edu.au/document/view-current.php?id=204'
+            href='https://www.newcastle.edu.au/__data/assets/pdf_file/0003/85701/code-of-conduct.pdf'
             target='_blank'
             rel='noopener noreferrer'
             title='View Code of Conduct'


### PR DESCRIPTION
The University has a fresh Code of Conduct PDF up online. The old link no longer works so this PR updates to the new one.

### Preview

<https://deploy-preview-287--nubook.netlify.com/>

Code of Conduct is in footer