### PR TITLE
Update references to DataLogging default output path

### DIFF
--- a/src/book/02-system/03-tools/06-natnet.mdx
+++ b/src/book/02-system/03-tools/06-natnet.mdx
@@ -60,11 +60,11 @@ This is the default method for running NatNet. If you wish to output motive pack
 
 7. Run Natnet using `./b run natnet`
 
-8. After your program has finished, check that a new nbs file has been created in `log/<your_program's_name>/`. The filename should be the date and timestamp when the file was run.
+8. After your program has finished, check that a new nbs file has been created in `recordings/<your_program's_name>/`. The filename should be the date and timestamp when the file was run.
 
 9. Exit out of the ssh of the robot.
 
-10. We now need to copy the nbs file off the robot. Use `scp nubots@10.1.1.<robot_id#>:/home/nubots/log/<your_program_name>/<name_of_nbs_file> ./log/`
+10. We now need to copy the nbs file off the robot. Use `scp nubots@10.1.1.<robot_id#>:/home/nubots/recordings/<your_program_name>/<name_of_nbs_file> ./recordings/`
 
 11. You now need to extract the information you want from the nbs file. We have a number of .nbs extraction tools and is recommended that you use `./b nbs extract_images <path>` for extracting images from the nbs file and `./b nbs json <path>` to extract the information into JSON format.
 
@@ -81,9 +81,9 @@ This method may be useful to determine if Motive is outputting packets directly 
 
 3. Run Natnet using `./b run natnet`
 
-4. After your program has finished, check that a new nbs file has been created in "log/<your_program's_name>/". The filename should be the date and timestamp when the file was run.
+4. After your program has finished, check that a new nbs file has been created in "recordings/<your_program's_name>/". The filename should be the date and timestamp when the file was run.
 
-5. You now need to extract the information you want from the nbs file. We have a few nbs decoders that have already been written for specific purposes. If one of those does not suit your needs, you will need to either modify an existing nbs extraction file, or write your own. The location of these nbs files is `nubots/tools/nbs_tools/`. For example purposes, let's assume you want to extract images and Motion Capture data. To run this program, make sure you are in the nubots home directory, then you would use: `./b nbs extract_images_MoCap ./log/<file_name> --output ./log/<your_extraction_folder>`
+5. You now need to extract the information you want from the nbs file. We have a few nbs decoders that have already been written for specific purposes. If one of those does not suit your needs, you will need to either modify an existing nbs extraction file, or write your own. The location of these nbs files is `nubots/tools/nbs_tools/`. For example purposes, let's assume you want to extract images and Motion Capture data. To run this program, make sure you are in the nubots home directory, then you would use: `./b nbs extract_images_MoCap ./recordings/<file_name> --output ./recordings/<your_extraction_folder>`
 
 </details>
 

--- a/src/book/03-guides/01-main-codebase/05-recording-playback.mdx
+++ b/src/book/03-guides/01-main-codebase/05-recording-playback.mdx
@@ -36,11 +36,6 @@ The following steps detail how to record data. An example will be given througho
 
      You can enable multiple messages at once, and they will all be recorded.
 
-   - **If** you are **not** running on a real robot, e.g. you are logging data from a simulator, change the output directory of the logs.
-
-     1. Find the line `directory: log` in the configuration file.
-     2. Change `log` to `recordings`.
-
 3. Build the code and install it to a robot. To find out how to do this, visit the [Getting Started](/guides/main/getting-started) page.
 
 4. Run the binary for the role you want to record.
@@ -57,18 +52,18 @@ The following steps detail how to record data. An example will be given througho
 
    **On a real robot:** You will need to move the file off the robot so that it is not lost and so that it can be used. Note that when someone else uses the robot any recordings may be lost, so immediately copy them to another computer.
 
-   1. The NBS file will be located on the robot in the `log/role_name/` folder. The name will correspond to the time and date it was created, according to the robot's clock. Make note of the name. In our example, this may be `log/test/sensor/18072020T082100.nbs`.
+   1. The NBS file will be located on the robot in the `recordings/role_name/` folder. The name will correspond to the time and date it was created, according to the robot's clock. Make note of the name. In our example, this may be `recordings/test/sensor/18072020T082100.nbs`.
    2. Copy the file across. On the destination computer, run:
 
       ```bash
-      scp nubots@<address>:log/rolename/file_name path/to/destination
+      scp nubots@<address>:recordings/rolename/file_name path/to/destination
       ```
 
       For our example, you could run:
 
       ```bash
       # Replace <address> with the robot's IP address
-      scp nubots@<address>:log/test/sensor/18072020T082100.nbs .
+      scp nubots@<address>:recordings/test/sensor/18072020T082100.nbs .
       ```
 
       The file will be copied from the robot to the folder you ran the command in. The [`scp`](https://linux.die.net/man/1/scp) command is like the regular [`cp`](https://linux.die.net/man/1/cp) command, but it copies to or from another computer over SSH. The first path in the command points to the file we are copying and the second path points to where we want to copy that file to.

--- a/src/book/03-guides/01-main-codebase/06-camera-calibration.mdx
+++ b/src/book/03-guides/01-main-codebase/06-camera-calibration.mdx
@@ -57,7 +57,7 @@ The calibration requires two steps, creating the `nbs` recording and using it to
 
     1. To stop the program running, hit <kbd>Ctrl</kbd> + <kbd>c</kbd>.
 
-    2. Discover the name of the log file created. The file is in the `log/test/camera/` folder on the robot. The name corresponds to the date and time it was created, according to the robot. Run `ls log/test/camera/` to list all logs.
+    2. Discover the name of the log file created. The file is in the `recordings/test/camera/` folder on the robot. The name corresponds to the date and time it was created, according to the robot. Run `ls recordings/test/camera/` to list all logs.
 
     3. (optional) Rename the log file, making it easier to copy across to the computer. Change the name with the command `mv <old path> <new path>`.
 


### PR DESCRIPTION
This PR updates references to `log/` as the DataLogging output directory to `recordings/`, to match https://github.com/NUbots/NUbots/pull/1282.

Changed pages:

- https://deploy-preview-301--nubook.netlify.app/system/tools/natnet_sdk
- https://deploy-preview-301--nubook.netlify.app/guides/main/data-recording-playback
- https://deploy-preview-301--nubook.netlify.app/guides/main/camera-calibration