### PR TITLE
Fix the preview link in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,6 @@ PR description here.
 
 ### Preview
 
-<https://deploy-preview-[PR_NUMBER]--nubook.netlify.com/[PAGE_SLUG]>
+<https://deploy-preview-[PR_NUMBER]--nubook.netlify.net/[PAGE_SLUG]>
 
 Note: Update `[PR_NUMBER]` to the number on this PR and `[PAGE_SLUG]` with the "slug" of the page you have updated/added. You can find the slug at the top of the page in the markdown file.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,6 @@ PR description here.
 
 ### Preview
 
-<https://deploy-preview-[PR_NUMBER]--nubook.netlify.net/[PAGE_SLUG]>
+<https://deploy-preview-[PR_NUMBER]--nubook.netlify.app/[PAGE_SLUG]>
 
 Note: Update `[PR_NUMBER]` to the number on this PR and `[PAGE_SLUG]` with the "slug" of the page you have updated/added. You can find the slug at the top of the page in the markdown file.


### PR DESCRIPTION
PR template is what shows up in the description text box when you make a PR.
Currently the link in the template is wrong, so this updates it (.app instead of .com).