### PR TITLE
Update team section, including current members

### DIFF
--- a/src/book/01-team/01-introduction/01-introduction-to-nubots.mdx
+++ b/src/book/01-team/01-introduction/01-introduction-to-nubots.mdx
@@ -22,13 +22,11 @@ The team is led and supported by academics and student team leaders.
 
 - **Professor Stephan Chalup** (Computer Science and Engineering) - Head of the Newcastle Robotics Lab and NUbots
 - **Dr. Alexandre Mendes** (Computer Science and Software Engineering) - Deputy Head of NUbots
-- **Ysobel Sims** (Mathematics and Computer Science) - Student Team Leader
-- **Thomas O'Brien** (Mechatronics) - Deputy Team Leader
-- **Liam Craft** (Computer Science) - Laboratory Manager
+- **Clayton Carlon** (Electrical and Electronics Engineering) - Student Team Leader
 - **Dr. Trent Houliston** (Software Engineering) - Mentor, Ex-Team Leader, 4AI Systems Liaison
 
 See [Current Team](/team/current-members) for our current team members and [Past Members](/team/past-members) for past members.
 
 ## The NUbots Lab
 
-The NUbots team works in the Robotics and Brain Architecting Laboratory in ES115A. Feel free to stop by at any time for a tour!
+The NUbots team works in the Robotics and Brain Architecting Laboratory in ES226. Feel free to stop by at any time for a tour!

--- a/src/book/01-team/01-introduction/03-current-team.mdx
+++ b/src/book/01-team/01-introduction/03-current-team.mdx
@@ -20,47 +20,62 @@ Left to right: Angelique Herfel, Dexter Konijn, Ysobel Sims, Thomas O'Brien, Lia
 
 - **Dr. Alexandre Mendes**: Senior Lecturer in the School of Information and Physical Sciences. Deputy Head of NUbots. Specialises in Machine Learning and Optimisation.
 
-- **Dr. Joel Ferguson**: Lecturer and research associate in the School of Engineering. Specialises in nonlinear control. Supervises NUbots Mechatronics final year projects in a range of areas.
+- **Dr. Alejandro Donaire**: Senior Lecturer in the School of Engineering. Specialises in control systems. Supervises NUbots Mechatronics final year projects in a range of areas.
 
 - **Dr. Khaled Saleh**: Lecturer in the School of Information and Physical Sciences. Specialises in Machine Learning and Autonomous Systems.
 
 ## Student Members
 
-- **Joe Bailey**: Undergraduate student studying Computer Science. Vision data generation and benchmarking.
+- **Joe Bailey**: Bachelor of Computer Science. Studying Computing Honours. Vision data generation and benchmarking.
+
+- **Ethan Bird**: Undergraduate student studying Software Engineering. Localisation.
+
+- **William Burgin**: Undergraduate student studying a Bachelor of Mechatronics Engineering. Localisation.
 
 - **Clayton Carlon**: Bachelor of Computer-Systems Engineering (Honours), Bachelor of Electrical and Electronic Engineering (Honours). Electrical Engineering PhD candidate. Team Leader. Electronics and audio signal processing.
 
 - **Liam Craft**: Bachelor of Computer Science. Studying Computing Honours. Laboratory Manager. Hardware design and machine learning.
 
+- **Hayden Farley**: Undergraduate student studying a combined degree in Computer Systems Engineering and Computer Science. Electronics and vision.
+
+- **Lucinda Fien**: Undergraduate student studying a Bachelor of Mechatronics Engineering. Motion.
+
 - **Angelique Herfel**: Undergraduate student studying Software Engineering. Vision and behaviour.
+
+- **Kim Khang Hoang**: Undergraduate student studing Computer Science. NUsight development.
 
 - **Dexter Konijn**: Undergraduate student studying a combined degree in Computer Systems Engineering and Physics. Deputy Team Leader. Electronics and localisation.
 
-- **Johanne Montano**: Undergraduate student studying a combined degree in Computer Systems Engineering and Mathematics. Recruitment Officer. Electronics and vision.
+- **Johanne Montano**: Undergraduate student studying a combined degree in Computer Systems Engineering and Mathematics. Electronics and vision.
+
+- **Minh Thai "Jimmy" Nguyen**: Undergraduate student studing Computer Science. Behaviour and path planning.
 
 - **Thomas O'Brien**: Bachelor of Mechatronics Engineering. Mechatronics Engineering PhD student. Motions, behaviour and localisation.
 
-- **Corah Oliver**: Undergraduate student studying Computer Science. Darwin-OP assembly and hardware design.
+- **Corah Oliver**: Undergraduate student studying Computer Science. Outreach Manager. Darwin-OP assembly and hardware design.
 
-- **Liam Patey-Dennis**: Undergraduate student studying Electrical Engineering. Electronics.
+- **Liam Patey-Dennis**: Undergraduate student studying Electrical Engineering. Outreach and Social Media Manager. Electronics.
 
-- **Jesse Perrin**: Bachelor of Computer Systems Engineering. Vision and machine learning.
+- **Ali Riyaz**: Undergraduate student studying Software Engineering. Reinforcement learning behaviour.
+
+- **Mithun Sivanesan**: Undergraduate student studying Software Engineering. Localisation and vision.
 
 - **Ysobel Sims**: Bachelor of Mathematics and Computer Science. Computer Science PhD student. Vision and behaviour.
 
-- **Cottrell Tamessar**: Biological Science PhD student. Vision.
+- **Vincent Tumminello**: Undergraduate student studying a Bachelor of Mechatronics Engineering. Motion.
 
 - **David Wieland**: Bachelor of IT. Postgraduate student studying a Master of Data Science. Specialises in community outreach, sponsorships and marketing.
-
-- **Jesse Williamson**: Undergraduate student studying Computer Science. Outreach Manager. DevOps and NUsight.
 
 - **Hengning "Henry" Xu**: Electrical Engineering PhD student. Control and reinforcement learning.
 
 ## Junior Members
 
-- **Ali Riyaz**, Undergraduate student studying Software Engineering
-- **Hayden Farley**, Undergraduate student studying combined Computer Systems Engineering and Computer Science
-- **Sebastian Catt**, Undergraduate student studying Computer Science
+- **Preeti Arora**, studying a Master of Data Analytics
+- **Samuel Flood**, studying a Bachelor of Mechatronics
+- **Isaac Leonard**, studying a Bachelor of Science
+- **Jo Lynch**, studying a Bachelor of Computer Science
+- **Claire Smith**, studying a Bachelor of Computer Science
+- **Sean Cyril Yu**, studying a Master of Mechanical Engineering
 
 ## Supporting Members
 
@@ -68,7 +83,7 @@ Past members of the team that are still involved with projects, mentoring, and s
 
 - **Brendan Annable**: Bachelor of Software Engineering Graduate. Ex-Team Leader. Lead Developer of NUsight.
 
-- **Alex Biddulph**: Bachelor of Computer Science, Bachelor of Computer Systems Engineering with Honours. Currently studying for a Doctorate of Philosophy in Computer Systems Engineering. Ex-Team Leader. Specialises in the Build System, Machine Learning and Computer Vision.
+- **Dr. Alex Biddulph**: Bachelor of Computer Science, Bachelor of Computer Systems Engineering with Honours. Currently studying for a Doctorate of Philosophy in Computer Systems Engineering. Ex-Team Leader. Specialises in the Build System, Machine Learning and Computer Vision.
 
 - **Kip Hamiltons**: Bachelor of Mathematics and Computer Science Graduate. Ex-Lead of DevOps.
 

--- a/src/book/01-team/01-introduction/03-current-team.mdx
+++ b/src/book/01-team/01-introduction/03-current-team.mdx
@@ -32,7 +32,7 @@ Left to right: Angelique Herfel, Dexter Konijn, Ysobel Sims, Thomas O'Brien, Lia
 
 - **William Burgin**: Undergraduate student studying a Bachelor of Mechatronics Engineering. Localisation.
 
-- **Clayton Carlon**: Bachelor of Computer-Systems Engineering (Honours), Bachelor of Electrical and Electronic Engineering (Honours). Electrical Engineering PhD candidate. Team Leader. Electronics and audio signal processing.
+- **Clayton Carlon**: Bachelor of Computer-Systems Engineering (Honours), Bachelor of Electrical and Electronic Engineering (Honours). Electrical Engineering PhD student. Team Leader. Electronics and audio signal processing.
 
 - **Liam Craft**: Bachelor of Computer Science. Studying Computing Honours. Laboratory Manager. Hardware design and machine learning.
 

--- a/src/book/01-team/02-joining/01-how-we-work.mdx
+++ b/src/book/01-team/02-joining/01-how-we-work.mdx
@@ -14,7 +14,7 @@ The NUbots development process is a combination of in-person and remote collabor
 
 ## Meetings and Lab Work
 
-We hold weekly meetings in the NUbots lab at **Friday 12-1pm**, with the option to call in via Zoom. The meeting time may change based on team members' availabilities.
+We hold weekly meetings in the NUbots lab with the option to call in via Zoom. The meeting time may change based on team members' availabilities.
 
 Team members have dedicated work spaces in the lab where they work at various times during the week.
 

--- a/src/book/01-team/02-joining/02-how-to-join.mdx
+++ b/src/book/01-team/02-joining/02-how-to-join.mdx
@@ -22,7 +22,7 @@ If you are interested in joining NUbots, there are a few ways to get involved.
 
 - One way is to join during our **official recruitment** period. Every year during Semester 2 we announce recruitment and provide a link to our application form on the [NUbots Facebook page](https://www.facebook.com/NubotsRobotics/).
 
-- Another way to join is to **come and talk to us** in the lab about your areas of interest and what you would like to do. We are located in the ES building on the Callaghan campus at [ES115A](https://studentvip.com.au/newcastle/newcastle/maps/99668).
+- Another way to join is to **come and talk to us** in the lab about your areas of interest and what you would like to do. We are located in the ES building on the Callaghan campus in ES226.
 
 - You can also join NUbots **through your studies**. We offer research projects to students in Work Integrated Learning, Honours, Final Year Projects, Masters and PhD programs. See our [areas of research](/team/areas-of-research) for a list of research areas we offer.
 

--- a/src/book/01-team/03-community/01-sponsors.mdx
+++ b/src/book/01-team/03-community/01-sponsors.mdx
@@ -20,11 +20,6 @@ authors:
 
 [![Tribotix logo](./images/tribotix.png)](https://tribotix.com/)
 
-[![Office of the NSW Chief Scientist & Engineer](./images/NSW_OCSE.png)](https://www.chiefscientist.nsw.gov.au)
-
-The Office of the NSW Chief Scientist & Engineer is committed to encouraging students to consider a future career in a science-, technology-, engineering- or mathematics-related (STEM-related) field.
-The Office offers funding to NSW high school and tertiary students participating in STEM-related courses, competitions and events through several programs including the Science & Engineering Challenge, the Supporting Young Scientists Equity and Access Program and the STEM Student Competition Sponsorship Program.
-
 [![Pritchard Electronics logo](./images/pritchard.png)](https://pritchardelectronics.com.au/)
 
 [![Elby Designs logo](./images/elby.png)](https://www.elby-designs.com/)


### PR DESCRIPTION
More minor things with location change, removed meeting time because this page isn't updated frequently enough for it to be useful, updated the intro page (very old, still had me as team leader), removed sponsorship that's ended now. Biggest change is the current members section. Seems to be a year or more old. I think we're trying to chase up some people so I'll give this some time to settle. @Claegtun you might want to have a look.

https://deploy-preview-328--nubook.netlify.app/team/current-members