### PR TITLE
Punch/fix latex formatting

### DIFF
--- a/src/book/02-system/05-modules/04-localisation.mdx
+++ b/src/book/02-system/05-modules/04-localisation.mdx
@@ -147,7 +147,7 @@ The optimization framework integrates several cost components and constraints to
 
    - Measures the alignment of predicted field lines with observed ones.
    - Calculated as the squared Euclidean distance between field line points and the nearest point on any observed line, scaled by a predefined weight:
-     $$ J_{\text{fl}} = w_{\text{fl}} \sum_{i=1}^{N} \left( \text{dist}(r_{\text{obs}_i}, r_{\text{line}}) \right)^2 $$
+     $$ J*{\text{fl}} = w*{\text{fl}} \sum*{i=1}^{N} \left( \text{dist}(r*{\text{obs}_i}, r_{\text{line}}) \right)^2 $$
 
 2. **Field Line Intersection Cost ($J_{\text{fi}}$)**:
 

--- a/src/book/02-system/05-modules/04-localisation.mdx
+++ b/src/book/02-system/05-modules/04-localisation.mdx
@@ -69,18 +69,18 @@ The optimization framework integrates several cost components and constraints to
 
    - Measures the alignment of predicted field lines with observed ones.
    - Calculated as the squared Euclidean distance between field line points and the nearest point on any observed line, scaled by a predefined weight:
-     $$ J*{\text{fl}} = w*{\text{fl}} \sum*{i=1}^{N} \left( \text{dist}(r*{\text{obs}_i}, r_{\text{line}}) \right)^2 $$
+     $$J_{\text{fl}} = w_{\text{fl}} \sum_{i=1}^{N} \left( \text{dist}(r_{\text{obs}_i}, r_{\text{line}}) \right)^2$$
 
 2. **Field Line Intersection Cost ($J_{\text{fi}}$)**:
 
    - Assesses the accuracy of predicted field line intersections against observed intersections.
    - Computed similarly through the squared distances between predicted and observed intersections:
-     $$ J*{\text{fi}} = w*{\text{fi}} \sum*{j=1}^{M} \left( \text{dist}(r*{\text{int}_j}, r_{\text{obs}\_j}) \right)^2 $$
+     $$J_{\text{fi}} = w_{\text{fi}} \sum_{j=1}^{M} \left( \text{dist}(r_{\text{int}_j}, r_{\text{obs}_j}) \right)^2$$
 
 3. **State Change Cost ($J_{\text{sc}}$)**:
    - Penalizes large deviations from the initial state estimate to ensure temporal consistency.
    - Expressed as:
-     $$ J*{\text{sc}} = w*{\text{sc}} \|\textbf{x} - \textbf{x}\_{\text{init}}\|^2 $$
+     $$J_{\text{sc}} = w_{\text{sc}} \|\textbf{x} - \textbf{x}_{\text{init}}\|^2$$
 
 #### Constraints
 
@@ -89,22 +89,22 @@ The optimization is subject to the following constraints:
 - **State Bounds**:
 
   - Limits the allowable state changes between optimization steps to ensure the solution does not jump an unrealisic amount between updates
-    $$ \textbf{x}_{\text{init}} - \Delta \textbf{x} \leq \textbf{x} \leq \textbf{x}_{\text{init}} + \Delta \textbf{x} $$
+    $$\textbf{x}_{\text{init}} - \Delta \textbf{x} \leq \textbf{x} \leq \textbf{x}_{\text{init}} + \Delta \textbf{x}$$
   - Here, $\Delta \textbf{x}$ represents the maximum allowable change in each state dimension (x, y, and $\theta$).
 
 - **Minimum Field Line Points**:
 
   - The algorithm requires a minimum number of field line points to run the optimization to ensure sufficient data for accurate estimation:
-    $$ \text{Count}(\text{field line points}) \geq \text{Min points} $$
+    $$\text{Count}(\text{field line points}) \geq \text{Min points}$$
 
 - **Robot Stability**:
   - Optimization will not proceed if the robot is in an unstable state (e.g., falling):
-    $$ \text{stability} > \text{FALLING} $$
+    $$\text{stability} > \text{FALLING}$$
 
 #### Optimization Algorithm
 
 - The overall cost function optimized is:
-  $$ J(\textbf{x}) = J*{\text{fl}} + J*{\text{fi}} + J\_{\text{sc}} $$
+  $$J(\textbf{x}) = J*{\text{fl}} + J*{\text{fi}} + J\_{\text{sc}}$$
 
 Where:
 

--- a/src/book/02-system/05-modules/04-localisation.mdx
+++ b/src/book/02-system/05-modules/04-localisation.mdx
@@ -104,7 +104,7 @@ The optimization is subject to the following constraints:
 #### Optimization Algorithm
 
 - The overall cost function optimized is:
-  $$J(\textbf{x}) = J*{\text{fl}} + J*{\text{fi}} + J\_{\text{sc}}$$
+  $$J(\textbf{x}) = J_{\text{fl}} + J_{\text{fi}} + J_{\text{sc}}$$
 
 Where:
 
@@ -147,7 +147,7 @@ The optimization framework integrates several cost components and constraints to
 
    - Measures the alignment of predicted field lines with observed ones.
    - Calculated as the squared Euclidean distance between field line points and the nearest point on any observed line, scaled by a predefined weight:
-     $$ J*{\text{fl}} = w*{\text{fl}} \sum*{i=1}^{N} \left( \text{dist}(r*{\text{obs}_i}, r_{\text{line}}) \right)^2 $$
+     $$ J_{\text{fl}} = w_{\text{fl}} \sum_{i=1}^{N} \left( \text{dist}(r_{\text{obs}_i}, r_{\text{line}}) \right)^2 $$
 
 2. **Field Line Intersection Cost ($J_{\text{fi}}$)**:
 


### PR DESCRIPTION
On the Localisation module page, several strings of LaTeX don't appear correctly; appearing as text rather than formatted maths. This may be due to the fact that some Markdown/MDX viewers are more forgiving with simple LaTeX syntax errors.
This PR removes spaces between the `$$` tags and the actual LaTeX body, as well as using proper sub-script notation `u*{x}`.

### Preview

<https://deploy-preview-345--nubook.netlify.app/system/modules/localisation/>