### PR TITLE
Fix issue with references not showing booktitle if volume or pages weren't included

### DIFF
--- a/build-plugins/gatsby-transformer-nubook-bibliography/ieee.csl
+++ b/build-plugins/gatsby-transformer-nubook-bibliography/ieee.csl
@@ -181,7 +181,7 @@
       <if type="paper-conference speech" match="any">
         <choose>
           <!-- Published Conference Paper -->
-          <if variable="collection-editor editor editorial-director issue page volume" match="any">
+          <if variable="collection-editor container-title editor editorial-director issue page volume" match="any">
             <group delimiter=", ">
               <group delimiter=" ">
                 <text term="in"/>

--- a/build-plugins/gatsby-transformer-nubook-bibliography/ieee.csl
+++ b/build-plugins/gatsby-transformer-nubook-bibliography/ieee.csl
@@ -179,28 +179,13 @@
   <macro name="event">
     <choose>
       <if type="paper-conference speech" match="any">
-        <choose>
-          <!-- Published Conference Paper -->
-          <if variable="collection-editor container-title editor editorial-director issue page volume" match="any">
-            <group delimiter=", ">
-              <group delimiter=" ">
-                <text term="in"/>
-                <text variable="container-title" font-style="italic"/>
-              </group>
-              <text variable="event-place"/>
-            </group>
-          </if>
-          <!-- Unpublished Conference Paper -->
-          <else>
-            <group delimiter=", ">
-              <group delimiter=" ">
-                <text term="presented at"/>
-                <text variable="event"/>
-              </group>
-              <text variable="event-place"/>
-            </group>
-          </else>
-        </choose>
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text term="in"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
+          <text variable="event-place"/>
+        </group>
       </if>
     </choose>
   </macro>

--- a/src/book/kitchen-sink/12-referencing.bib
+++ b/src/book/kitchen-sink/12-referencing.bib
@@ -7,6 +7,15 @@
   organization={Springer}
 }
 
+@inproceedings{Khan2026,
+  title={A Great Conference Paper with no Pages or Volume},
+  author={Khan, Alice and Xu, Bob},
+  booktitle={A Great Conference on AI},
+  year={2026},
+  month={January},
+  address={Newcastle, Australia}
+}
+
 @article{flomo2018,
 Author = "Emmanuel Flomo",
 Title = "The Practical Benefits of Unit Testing",

--- a/src/book/kitchen-sink/12-referencing.mdx
+++ b/src/book/kitchen-sink/12-referencing.mdx
@@ -26,7 +26,7 @@ Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ab ducimus, ipsum libe
 
 Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ab ducimus, ipsum libero quo quae blanditiis hic <cite>wong2018robocup</cite>. Impedit dicta ex perferendis at unde iure, aut necessitatibus molestiae ad ipsam reiciendis facilis.
 
-Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ab ducimus, ipsum libero quo quae blanditiis hic. Impedit dicta ex perferendis at unde iure.
+Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ab ducimus, ipsum libero quo quae blanditiis hic <cite>Khan2026</cite>. Impedit dicta ex perferendis at unde iure.
 
 ## References
 


### PR DESCRIPTION
Addresses Issue #296.

`inproceedings` is rendered either as a _published_ or _unpublished_ talk - which it is, is determined based on what fields are filled. When volume/pages/issue isn't filled, it assumes it's _unpublished_. Unpublished doesn't render `booktitle`, it uses the `event` key instead. However, our plain BibTeX set up apparently cannot actually use the event key, so the unpublished branch on the IEEE class is redundant at best and causes issues at worst. This PR removes the if logic around published/unpublished `inproceedings`, and just uses the normal published model.

An example reference is added to the kitchen sink. Before, the booktitle wouldn't display. Now, it does.

<https://deploy-preview-362--nubook.netlify.app/kitchen-sink/referencing>